### PR TITLE
Fix zlib. Add a test case.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,22 +1,16 @@
 #!/bin/bash
 
-export CFLAGS="-Wall -g -m64 -pipe -O3 -march=x86-64 -fPIC"
-export CXXFLAGS="${CFLAGS}"
-
-if [ "$(uname)" == "Darwin" ];
-then
-    export LIBRARY_SEARCH_VAR=DYLD_FALLBACK_LIBRARY_PATH
-elif [ "$(uname)" == "Linux" ];
-then
-    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
-fi
-
 ./configure \
         --prefix="${PREFIX}" \
-        --enable-shared \
-        --enable-pic \
-        --enable-libx264 \
         --disable-doc \
-        --enable-gpl
+        --enable-shared \
+        --enable-static \
+        --extra-cflags="-Wall -g -m64 -pipe -O3 -march=x86-64 -fPIC `pkg-config --cflags zlib`" \
+        --extra-cxxflags=="-Wall -g -m64 -pipe -O3 -march=x86-64 -fPIC" \
+        --extra-libs="`pkg-config --libs zlib`" \
+        --enable-pic \
+        --enable-gpl \
+        --enable-libx264
+
 make
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
     skip: true         # [win]
-    number: 1
+    number: 2
 
 requirements:
     build:
@@ -29,6 +29,7 @@ requirements:
 test:
     commands:
         - ffmpeg --help
+        - ffmpeg -codecs | grep "DEVI.S zlib"  # [unix]
 
 about:
     home: http://www.ffmpeg.org/
@@ -39,3 +40,4 @@ extra:
     recipe-maintainers:
         - danielballan
         - jakirkham
+        - 183amir


### PR DESCRIPTION
Apparently `ffmpeg` assumes that `zlib` is installed in standard directories only.
This patch fixes https://github.com/conda-forge/ffmpeg-feedstock/issues/2.