### PR TITLE
Include windows headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: generic
 
 os: osx
-osx_image: xcode6.4
+osx_image: beta-xcode6.1
 
 env:
   global:
@@ -14,7 +14,7 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force --ignore-dependencies $(brew list)
+    - brew remove --force $(brew list)
     - brew cleanup -s
     - rm -rf $(brew --cache)
 
@@ -26,8 +26,6 @@ install:
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root
-      conda config --remove channels defaults
-      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,19 +42,23 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add path, activate `conda` and update conda.
-    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
-
-    - cmd: set PYTHONUNBUFFERED=1
-
     # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
     - cmd: conda config --add channels conda-forge
 
-    # Configure the VM.
+    # Add a hack to switch to `conda` version `4.1.12` before activating.
+    # This is required to handle a long path activation issue.
+    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
+    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
+
+    # Actually activate `conda`.
+    - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: set PYTHONUNBUFFERED=1
+
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults
+ - defaults # As we need conda-build
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v "${RECIPE_ROOT}":/recipe_root \
-                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
+                        -v ${RECIPE_ROOT}:/recipe_root \
+                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -5,9 +5,15 @@ curl -L -O "https://ffmpeg.zeranoe.com/builds/win%ARCH%/dev/%FFMPEG_FN%-dev.7z"
 7za x %SRC_DIR%\%FFMPEG_FN%-shared.7z -o%SRC_DIR%
 7za x %FFMPEG_FN%-dev.7z -o%SRC_DIR%
 
-copy %SRC_DIR%\%FFMPEG_FN%-shared\bin %LIBRARY_BIN%
-copy %SRC_DIR%\%FFMPEG_FN%-dev\include %LIBRARY_INC%
-copy %SRC_DIR%\%FFMPEG_FN%-dev\lib %LIBRARY_LIB%
+robocopy %SRC_DIR%\%FFMPEG_FN%-shared\bin\ %LIBRARY_BIN%\ *.* /E
+if %ERRORLEVEL% GEQ 8 exit 1
+
+robocopy %SRC_DIR%\%FFMPEG_FN%-dev\include\ %LIBRARY_INC%\ *.* /E
+if %ERRORLEVEL% GEQ 8 exit 1
+
+robocopy %SRC_DIR%\%FFMPEG_FN%-dev\lib\ %LIBRARY_LIB%\ *.* /E
+if %ERRORLEVEL% GEQ 8 exit 1
+
 copy %SRC_DIR%\%FFMPEG_FN%-shared\README.txt %RECIPE_DIR%
 
 mkdir %RECIPE_DIR%\licenses

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,9 @@
 set FFMPEG_FN=ffmpeg-%PKG_VERSION%-win%ARCH%
 
-Invoke-WebRequest "https://ffmpeg.zeranoe.com/builds/win%ARCH%/dev/%FFMPEG_FN%-dev.7z" -OutFile "%SRC_DIR%\%FFMPEG_FN%-dev.7z"
+curl -L -O "https://ffmpeg.zeranoe.com/builds/win%ARCH%/dev/%FFMPEG_FN%-dev.7z"
 
 7za x %SRC_DIR%\%FFMPEG_FN%-shared.7z -o%SRC_DIR%
-7za x %SRC_DIR%\%FFMPEG_FN%-dev.7z -o%SRC_DIR%
+7za x %FFMPEG_FN%-dev.7z -o%SRC_DIR%
 
 copy %SRC_DIR%\%FFMPEG_FN%-shared\bin %LIBRARY_BIN%
 copy %SRC_DIR%\%FFMPEG_FN%-dev\include %LIBRARY_INC%

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,6 @@ copy %SRC_DIR%\%FFMPEG_FN%-dev\lib %LIBRARY_LIB%
 copy %SRC_DIR%\%FFMPEG_FN%-shared\README.txt %RECIPE_DIR%
 
 mkdir %RECIPE_DIR%\licenses
-copy %SRC_DIR%\%FFMPEG_FN%-shared\lincenses %RECIPE_DIR%\licenses
+copy %SRC_DIR%\%FFMPEG_FN%-shared\licenses %RECIPE_DIR%\licenses
 
 exit 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,8 +1,16 @@
-set FFMPEG_FN=ffmpeg-2.8.6-win%ARCH%-shared
+set FFMPEG_FN=ffmpeg-%PKG_VERSION%-win%ARCH%
 
-7za x %SRC_DIR%\%FFMPEG_FN%.7z -o%SRC_DIR%
-mkdir %SCRIPTS%
-copy %SRC_DIR%\%FFMPEG_FN%\bin %SCRIPTS%
-copy %SRC_DIR%\%FFMPEG_FN%\licenses %SCRIPTS%
-copy %SRC_DIR%\%FFMPEG_FN%\README.txt %SCRIPTS%
-copy %SRC_DIR%\%FFMPEG_FN%\ff-prompt.bat %SCRIPTS%
+Invoke-WebRequest "https://ffmpeg.zeranoe.com/builds/win%ARCH%/dev/%FFMPEG_FN%-dev.7z" -OutFile "%SRC_DIR%\%FFMPEG_FN%-dev.7z"
+
+7za x %SRC_DIR%\%FFMPEG_FN%-shared.7z -o%SRC_DIR%
+7za x %SRC_DIR%\%FFMPEG_FN%-dev.7z -o%SRC_DIR%
+
+copy %SRC_DIR%\%FFMPEG_FN%-shared\bin %LIBRARY_BIN%
+copy %SRC_DIR%\%FFMPEG_FN%-dev\include %LIBRARY_INC%
+copy %SRC_DIR%\%FFMPEG_FN%-dev\lib %LIBRARY_LIB%
+copy %SRC_DIR%\%FFMPEG_FN%-shared\README.txt %RECIPE_DIR%
+
+mkdir %RECIPE_DIR%\licenses
+copy %SRC_DIR%\%FFMPEG_FN%-shared\lincenses %RECIPE_DIR%\licenses
+
+exit 0

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,10 +1,27 @@
+@echo ON
+
 set FFMPEG_FN=ffmpeg-%PKG_VERSION%-win%ARCH%
 
-curl -L -O "https://ffmpeg.zeranoe.com/builds/win%ARCH%/dev/%FFMPEG_FN%-dev.7z"
+rem On a version update, change the following SHA256 hashes (win32 and win64)
+if %ARCH% == 32 (
+    set FFMPEG_SHA256="SHA256(%FFMPEG_FN%-dev.7z)= 399cf13962a576a75b1b2850eb80d591f17767876adcb93c783bbbbd7e130e9a"
+) else (
+    set FFMPEG_SHA256="SHA256(%FFMPEG_FN%-dev.7z)= abebb0cb20328905b95d3bd24af3f87922278e0c8fd387306e0ff5621434c425"
+)
 
+rem Download the source and check the SHA256
+curl -L -O "https://ffmpeg.zeranoe.com/builds/win%ARCH%/dev/%FFMPEG_FN%-dev.7z"
+openssl dgst -sha256 -out sha256.out %FFMPEG_FN%-dev.7z
+SET /p DOWNLOADED_SHA256=<sha256.out
+if NOT "%DOWNLOADED_SHA256%" == %FFMPEG_SHA256% (
+    exit 1
+)
+
+rem Extract the archives
 7za x %SRC_DIR%\%FFMPEG_FN%-shared.7z -o%SRC_DIR%
 7za x %FFMPEG_FN%-dev.7z -o%SRC_DIR%
 
+rem Copy over the bin, include and lib dirs
 robocopy %SRC_DIR%\%FFMPEG_FN%-shared\bin\ %LIBRARY_BIN%\ *.* /E
 if %ERRORLEVEL% GEQ 8 exit 1
 
@@ -14,9 +31,9 @@ if %ERRORLEVEL% GEQ 8 exit 1
 robocopy %SRC_DIR%\%FFMPEG_FN%-dev\lib\ %LIBRARY_LIB%\ *.* /E
 if %ERRORLEVEL% GEQ 8 exit 1
 
-copy %SRC_DIR%\%FFMPEG_FN%-shared\README.txt %RECIPE_DIR%
-
-mkdir %RECIPE_DIR%\licenses
-copy %SRC_DIR%\%FFMPEG_FN%-shared\licenses %RECIPE_DIR%\licenses
+rem Add the licences to the recipe directory
+copy "%SRC_DIR%\%FFMPEG_FN%-shared\README.txt" "%RECIPE_DIR%"
+mkdir "%RECIPE_DIR%\licenses"
+copy "%SRC_DIR%\%FFMPEG_FN%-shared\licenses" "%RECIPE_DIR%\licenses"
 
 exit 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,3 +49,4 @@ extra:
         - danielballan
         - jakirkham
         - 183amir
+        - caspervdw

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,6 +30,7 @@ requirements:
         - zlib 1.2.*   # [not win]
         - 7za          # [win] 
         - curl         # [win]
+        - openssl      # [win]
     run:
         - libgcc       # [osx]
         - x264         # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     sha256: efe0e446391676aff51c575978f915ddae5358f49c44ab174ed128ba1ad2de2b  # [win64]
 
 build:
-    number: 3
+    number: 4
 
 requirements:
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
         - x264         # [not win]
         - zlib 1.2.*   # [not win]
         - 7za          # [win] 
+        - curl         # [win]
     run:
         - libgcc       # [osx]
         - x264         # [not win]


### PR DESCRIPTION
This addresses #20 by downloading the ffmpeg sources and copying them over in their respective `%LIBRARY_xx%` paths. Instead of using `%SCRIPTS%` to distribute the `bin` folder, I used `%LIBRARY_BIN%`. For the licenses, I used `%RECIPE_DIR%`.