### PR TITLE
Various OS X fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   global:
@@ -13,19 +13,38 @@ env:
 
 
 before_install:
+    # Fast finish the PR.
+    - |
+      (curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+          python - -v --ci "travis" "${TRAVIS_REPO_SLUG}" "${TRAVIS_BUILD_NUMBER}" "${TRAVIS_PULL_REQUEST}") || exit 1
+
     # Remove homebrew.
-    - brew remove --force $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
       MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
       curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,35 +30,27 @@ platform:
 
 install:
     # If there is a newer build queued for the same PR, cancel this one.
-    # The AppVeyor 'rollout builds' option is supposed to serve the same
-    # purpose but it is problematic because it tends to cancel builds pushed
-    # directly to master instead of just PR builds (or the converse).
-    # credits: JuliaLang developers.
-    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-          throw "There are newer queued builds for this pull request, failing early." }
+    - cmd: |
+        powershell -Command "(New-Object Net.WebClient).DownloadFile('https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py', 'ff_ci_pr_build.py')"
+        ff_ci_pr_build -v --ci "appveyor" "%APPVEYOR_ACCOUNT_NAME%/%APPVEYOR_PROJECT_SLUG%" "%APPVEYOR_BUILD_NUMBER%" "%APPVEYOR_PULL_REQUEST_NUMBER%"
+        del ff_ci_pr_build.py
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add our channels.
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --add channels conda-forge
-
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: conda install --yes --quiet conda=4.1.12
-    - cmd: set "PATH=%OLDPATH%"
-    - cmd: set "OLDPATH="
-
-    # Actually activate `conda`.
+    # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
+
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --remove channels defaults
+    - cmd: conda config --add channels defaults
+    - cmd: conda config --add channels conda-forge
+
+    # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup

--- a/ci_support/fast_finish_ci_pr_build.sh
+++ b/ci_support/fast_finish_ci_pr_build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-build-setup-feedstock/master/recipe/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -24,12 +24,14 @@ show_channel_urls: true
 CONDARC
 )
 
+rm -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done"
+
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
-                        bash || exit $?
+                        bash || exit 1
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
 export PYTHONUNBUFFERED=1
@@ -44,4 +46,11 @@ source run_conda_forge_build_setup
 # Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+touch /feedstock_root/build_artefacts/conda-forge-build-done
 EOF
+
+# double-check that the build got to the end
+# see https://github.com/conda-forge/conda-smithy/pull/337
+# for a possible fix
+set -x
+test -f "$FEEDSTOCK_ROOT/build_artefacts/conda-forge-build-done" || exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 checkout:
   post:
+    - ./ci_support/fast_finish_ci_pr_build.sh
     - ./ci_support/checkout_merge_commit.sh
 
 machine:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: ffmpeg-{{ version }}.tar.gz  # [not win]
   url: https://ffmpeg.org/releases/ffmpeg-{{ version }}.tar.gz  # [not win]
-  md5: 7b9449795790c46331dae2c6e8e28f15  # [not win]
+  sha256: f4c1dfe5a0adc04bc9ca164cf96e32bee97b2994ec06de2a40af2ba5d2b1b9d9  # [not win]
     
   fn: ffmpeg-{{ version }}-win32-shared.7z  # [win32]
   url: https://ffmpeg.zeranoe.com/builds/win32/shared/ffmpeg-{{ version }}-win32-shared.7z  # [win32]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
 about:
   home: http://www.ffmpeg.org/
   license: GPL 2
+  license_file: COPYING.GPLv2  # [unix]
   summary: Cross-platform solution to record, convert and stream audio and video.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,12 +26,16 @@ requirements:
     - pkg-config   # [not win]
     - libtool      # [not win]
     - yasm         # [not win]
+    - bzip2 1.0.*  # [not win]
+    - libiconv     # [not win]
     - x264         # [not win]
     - zlib 1.2.*   # [not win]
     - 7za          # [win]
     - curl         # [win]
     - openssl      # [win]
   run:
+    - bzip2 1.0.*  # [not win]
+    - libiconv     # [not win]
     - x264         # [not win]
     - zlib 1.2.*   # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,54 +1,54 @@
 {% set version = "2.8.6" %}
 
 package:
-    name: ffmpeg
-    version: {{ version }}
+  name: ffmpeg
+  version: {{ version }}
 
 source:
-    fn: ffmpeg-{{ version }}.tar.gz  # [not win]
-    url: https://ffmpeg.org/releases/ffmpeg-{{ version }}.tar.gz  # [not win]
-    md5: 7b9449795790c46331dae2c6e8e28f15  # [not win]
+  fn: ffmpeg-{{ version }}.tar.gz  # [not win]
+  url: https://ffmpeg.org/releases/ffmpeg-{{ version }}.tar.gz  # [not win]
+  md5: 7b9449795790c46331dae2c6e8e28f15  # [not win]
     
-    fn: ffmpeg-{{ version }}-win32-shared.7z  # [win32]
-    url: https://ffmpeg.zeranoe.com/builds/win32/shared/ffmpeg-{{ version }}-win32-shared.7z  # [win32]
-    sha256: 192117a332d08c53412c3c52b32eac8fca72db874509a627b7b41e55eab3396c  # [win32]
+  fn: ffmpeg-{{ version }}-win32-shared.7z  # [win32]
+  url: https://ffmpeg.zeranoe.com/builds/win32/shared/ffmpeg-{{ version }}-win32-shared.7z  # [win32]
+  sha256: 192117a332d08c53412c3c52b32eac8fca72db874509a627b7b41e55eab3396c  # [win32]
 
-    fn: ffmpeg-{{ version }}-win64-shared.7z  # [win64]
-    url: https://ffmpeg.zeranoe.com/builds/win64/shared/ffmpeg-{{ version }}-win64-shared.7z  # [win64]
-    sha256: efe0e446391676aff51c575978f915ddae5358f49c44ab174ed128ba1ad2de2b  # [win64]
+  fn: ffmpeg-{{ version }}-win64-shared.7z  # [win64]
+  url: https://ffmpeg.zeranoe.com/builds/win64/shared/ffmpeg-{{ version }}-win64-shared.7z  # [win64]
+  sha256: efe0e446391676aff51c575978f915ddae5358f49c44ab174ed128ba1ad2de2b  # [win64]
 
 build:
-    number: 4
+  number: 4
 
 requirements:
-    build:
-        - pkg-config   # [not win]
-        - libtool      # [not win]
-        - yasm         # [not win]
-        - gcc          # [osx]
-        - x264         # [not win]
-        - zlib 1.2.*   # [not win]
-        - 7za          # [win] 
-        - curl         # [win]
-        - openssl      # [win]
-    run:
-        - libgcc       # [osx]
-        - x264         # [not win]
-        - zlib 1.2.*   # [not win]
+  build:
+    - pkg-config   # [not win]
+    - libtool      # [not win]
+    - yasm         # [not win]
+    - gcc          # [osx]
+    - x264         # [not win]
+    - zlib 1.2.*   # [not win]
+    - 7za          # [win]
+    - curl         # [win]
+    - openssl      # [win]
+  run:
+    - libgcc       # [osx]
+    - x264         # [not win]
+    - zlib 1.2.*   # [not win]
 
 test:
-    commands:
-        - ffmpeg --help
-        - ffmpeg -codecs | grep "DEVI.S zlib"  # [unix]
+  commands:
+    - ffmpeg --help
+    - ffmpeg -codecs | grep "DEVI.S zlib"  # [unix]
 
 about:
-    home: http://www.ffmpeg.org/
-    license: GPL 2
-    summary: Cross-platform solution to record, convert and stream audio and video.
+  home: http://www.ffmpeg.org/
+  license: GPL 2
+  summary: Cross-platform solution to record, convert and stream audio and video.
 
 extra:
-    recipe-maintainers:
-        - danielballan
-        - jakirkham
-        - 183amir
-        - caspervdw
+  recipe-maintainers:
+    - danielballan
+    - jakirkham
+    - 183amir
+    - caspervdw

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,17 +22,16 @@ build:
 
 requirements:
   build:
+    - toolchain    # [not win]
     - pkg-config   # [not win]
     - libtool      # [not win]
     - yasm         # [not win]
-    - gcc          # [osx]
     - x264         # [not win]
     - zlib 1.2.*   # [not win]
     - 7za          # [win]
     - curl         # [win]
     - openssl      # [win]
   run:
-    - libgcc       # [osx]
     - x264         # [not win]
     - zlib 1.2.*   # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
   sha256: efe0e446391676aff51c575978f915ddae5358f49c44ab174ed128ba1ad2de2b  # [win64]
 
 build:
-  number: 4
+  number: 5
 
 requirements:
   build:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/ffmpeg-feedstock/issues/9
Fixes https://github.com/conda-forge/ffmpeg-feedstock/issues/22

* Use the `toolchain`.
* Rebuild with the new `x264`, which also uses the `toolchain`.
* Package the GPL2 license as we are under GPL2 in this build.
* Re-render with `conda-smithy` 2.2.2.
* Use `sha256` with the Unix source.
* Require `bzip2` and `libiconv` to avoid system linkages.
* Bump the build number for a fresh build.
* Style fixes.