### PR TITLE
Add libavresample - borrowed from homebrew

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,6 +13,9 @@ unset SUBDIR
         --extra-libs="`pkg-config --libs zlib`" \
         --enable-pic \
         --enable-gpl \
+        --enable-version3 \
+        --enable-hardcoded-tables \
+        --enable-avresample \
         --enable-libx264
 
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
   sha256: 31dab0e45aa2808fc422927eca5d49761985d1471b7122aadc6f85deb7bf6a7f  # [win64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -43,6 +43,23 @@ test:
   commands:
     - ffmpeg --help
     - ffmpeg -codecs | grep "DEVI.S zlib"  # [unix]
+    # Verify dynamic libraries on all systems
+    {% set ffmpeg_libs = [
+        "avcodec",
+        "avdevice",
+        "swresample",
+        "postproc",
+        "avfilter",
+        "swresample",
+        "avcodec",
+        "avformat",
+        "swscale",
+        "avresample"
+    ] %}
+    {% for each_ffmpeg_lib in ffmpeg_libs %}
+    - test -f $PREFIX/lib/lib{{ each_ffmpeg_lib }}.dylib  # [osx]
+    - test -f $PREFIX/lib/lib{{ each_ffmpeg_lib }}.so     # [linux]
+    {% endfor %}
 
 about:
   home: http://www.ffmpeg.org/
@@ -56,3 +73,4 @@ extra:
     - jakirkham
     - 183amir
     - caspervdw
+    - patricksnape


### PR DESCRIPTION
This adds libavresample and copies other flags from the homebrew recipe that seem to be reasonable.