### PR TITLE
Add freetype (drawfilter support), bump to GPLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About ffmpeg
 
 Home: http://www.ffmpeg.org/
 
-Package license: GPL 2
+Package license: GPL 3
 
 Feedstock license: BSD 3-Clause
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,24 +35,24 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 
 # Skip .NET project specific build phase.
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,7 @@ unset SUBDIR
         --enable-version3 \
         --enable-hardcoded-tables \
         --enable-avresample \
+        --enable-libfreetype \
         --enable-libx264
 
 make

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -67,8 +67,8 @@ test:
 
 about:
   home: http://www.ffmpeg.org/
-  license: GPL 2
-  license_file: COPYING.GPLv2  # [unix]
+  license: GPL 3
+  license_file: COPYING.GPLv3  # [unix]
   summary: Cross-platform solution to record, convert and stream audio and video.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,3 +79,4 @@ extra:
     - caspervdw
     - patricksnape
     - ocefpaf
+    - sdvillal

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - libtool      # [not win]
     - yasm         # [not win]
     - bzip2 1.0.*  # [not win]
+    - freetype 2.8.1     # [not win]
     - libiconv 1.15     # [not win]
     - x264         # [not win]
     - zlib 1.2.11   # [not win]
@@ -35,6 +36,7 @@ requirements:
     - openssl      # [win]
   run:
     - bzip2 1.0.*  # [not win]
+    - freetype 2.8.1     # [not win]
     - libiconv 1.15     # [not win]
     - x264         # [not win]
     - zlib 1.2.11   # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
   sha256: 14eca81117af4c081d820d5bb669437ac9380060feaecb1d438188daf3eaca96  # [win64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
- Compiles against freetype (enables drawtext filter, tackles #28). 

- Bumps to GPLv3 (all linux, mac, and windows builds use "--enable-version3" as a build option).