### PR TITLE
Pin x264 dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
   sha256: 8fe2d344463dbefc2db4239a4203a55ed0324faceaae57276a40c4fabda84c37  # [win64]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -45,7 +45,7 @@ requirements:
     - bzip2  # [not win]
     - freetype  # [not win]
     - libiconv  # [not win]
-    - x264  # [not win]
+    - {{ pin_compatible('x264') }}  # [not win]
     - zlib  # [not win]
     - gnutls  # [not win]
 


### PR DESCRIPTION
This is the more proper resolution of x264-feedstock issue 16, according to isuruf on slack who guided me through this change

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
