### PR TITLE
No hardcoded openh264 and gnutls pins

### DIFF
--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -6,27 +6,19 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-curl:
-- '7.59'
 docker_image:
 - condaforge/linux-anvil
 freetype:
 - 2.9.1
 libiconv:
 - '1.15'
-openssl:
-- 1.0.2
 pin_run_as_build:
   bzip2:
-    max_pin: x
-  curl:
     max_pin: x
   freetype:
     max_pin: x
   libiconv:
     max_pin: x.x
-  openssl:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
 x264:

--- a/.ci_support/osx_.yaml
+++ b/.ci_support/osx_.yaml
@@ -8,8 +8,6 @@ channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
-curl:
-- '7.59'
 freetype:
 - 2.9.1
 libiconv:
@@ -18,19 +16,13 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-openssl:
-- 1.0.2
 pin_run_as_build:
   bzip2:
-    max_pin: x
-  curl:
     max_pin: x
   freetype:
     max_pin: x
   libiconv:
     max_pin: x.x
-  openssl:
-    max_pin: x.x.x
   zlib:
     max_pin: x.x
 x264:

--- a/.ci_support/win_c_compilervs2008.yaml
+++ b/.ci_support/win_c_compilervs2008.yaml
@@ -1,5 +1,3 @@
-bzip2:
-- '1'
 c_compiler:
 - vs2008
 channel_sources:
@@ -8,26 +6,10 @@ channel_targets:
 - conda-forge main
 curl:
 - '7.59'
-freetype:
-- 2.9.1
-libiconv:
-- '1.15'
 openssl:
 - 1.0.2
 pin_run_as_build:
-  bzip2:
-    max_pin: x
   curl:
     max_pin: x
-  freetype:
-    max_pin: x
-  libiconv:
-    max_pin: x.x
   openssl:
     max_pin: x.x.x
-  zlib:
-    max_pin: x.x
-x264:
-- 1!152.*
-zlib:
-- '1.2'

--- a/.ci_support/win_c_compilervs2015.yaml
+++ b/.ci_support/win_c_compilervs2015.yaml
@@ -1,5 +1,3 @@
-bzip2:
-- '1'
 c_compiler:
 - vs2015
 channel_sources:
@@ -8,26 +6,10 @@ channel_targets:
 - conda-forge main
 curl:
 - '7.59'
-freetype:
-- 2.9.1
-libiconv:
-- '1.15'
 openssl:
 - 1.0.2
 pin_run_as_build:
-  bzip2:
-    max_pin: x
   curl:
     max_pin: x
-  freetype:
-    max_pin: x
-  libiconv:
-    max_pin: x.x
   openssl:
     max_pin: x.x.x
-  zlib:
-    max_pin: x.x
-x264:
-- 1!152.*
-zlib:
-- '1.2'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: ede566aca8b5348dff85570f9638c6bad33209f9419f79db7bde7daa37599bff  # [win]
 
 build:
-  number: 1
+  number: 2
   run_exports:
   # seems to be minor version compatibility
   # https://abi-laboratory.pro/tracker/timeline/ffmpeg/
@@ -37,16 +37,16 @@ requirements:
   host:
     - bzip2  # [not win]
     - freetype  # [not win]
-    - gnutls 3.5.*  # [not win]
+    - gnutls  # [not win]
     - libiconv  # [not win]
     - x264  # [not win]
     - zlib  # [not win]
-    - openh264 1.7.*  # [not win]
+    - openh264  # [not win]
   run:
     - bzip2  # [not win]
     - freetype  # [not win]
-    - gnutls 3.5.*  # [not win]
-    - openh264 1.7.*  # [not win]
+    - gnutls  # [not win]
+    - openh264  # [not win]
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

Now these packages export proper pins

Fixes #61 