### PR TITLE
PR to enable MPEG-DASH demuxing support

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,12 +9,14 @@ unset SUBDIR
         --disable-doc \
         --disable-openssl \
         --enable-avresample \
+        --enable-demuxer=dash \
         --enable-gnutls \
         --enable-gpl \
         --enable-hardcoded-tables \
         --enable-libfreetype \
         --enable-libopenh264 \
         --enable-libx264 \
+        --enable-libxml2 \
         --enable-pic \
         --enable-pthreads \
         --enable-shared \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ source:
     sha256: ce59245b32d3ef6fe74b48634ef4d05e8d7efa08fe21e1de5602ed42c2bfed02  # [win]
 
 build:
-  number: 0
+  number: 1
   run_exports:
   # seems to be minor version compatibility
   # https://abi-laboratory.pro/tracker/timeline/ffmpeg/
@@ -35,6 +35,7 @@ requirements:
     - freetype  # [not win]
     - gnutls  # [not win]
     - libiconv  # [not win]
+    - libxml2
     - x264  # [not win]
     - zlib  # [not win]
     - openh264  # [not win]
@@ -46,6 +47,7 @@ requirements:
     - gnutls  # [not win]
     - openh264  # [not win]
     - lame  # [not win]
+    - libxml2
     - gmp  # [unix]
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - freetype  # [not win]
     - gnutls  # [not win]
     - libiconv  # [not win]
-    - libxml2
+    - libxml2  # [not win]
     - x264  # [not win]
     - zlib  # [not win]
     - openh264  # [not win]
@@ -47,7 +47,7 @@ requirements:
     - gnutls  # [not win]
     - openh264  # [not win]
     - lame  # [not win]
-    - libxml2
+    - libxml2 # [not win] 
     - gmp  # [unix]
 
 test:


### PR DESCRIPTION
PR for #82 to enable MPEG-DASH demuxing support.

Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

`conda-build recipe` works on both osx and Linux.
`python build-locally.py linux_aarch64_` works on Linux.
Add `# [not win]` for `libxml2` as other dependencies but not so sure about build for windows.
