### PR TITLE
Set package.version to semver for auto update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.3.0" %} # semver: (x.y.z)
+{% set version = "4.3.1" %} # semver: (x.y.z)
 {% set x,y,z = version.split('.') %}
 {% set version_ffmpeg_style = x ~ '.' ~ y if z == "0" else version %}
 
@@ -17,7 +17,7 @@ source:
     sha256: 019a81f79ef88f8465a807f8fa2a416836810d7775a933cbde519e2eff69ead9  # [win]
 
 build:
-  number: 1
+  number: 0
   run_exports:
   # seems to be minor version compatibility
   # https://abi-laboratory.pro/tracker/timeline/ffmpeg/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,13 +8,13 @@ package:
 
 source:
   - url: https://ffmpeg.org/releases/ffmpeg-{{ version_ffmpeg_style }}.tar.gz  # [not win]
-    sha256: 95edf444cc46509ea1fea85d99ecd40a597a873627483ef9b068796feb3bf72a  # [not win]
+    sha256: 45035f15d6f192772de2309c846e1d60472694f479679354a39c699719e53772  # [not win]
 
   - url: https://ffmpeg.zeranoe.com/builds/win64/shared/ffmpeg-{{ version_ffmpeg_style }}-win64-shared.zip  # [win]
-    sha256: f468ebccdd23116f03b6f5561bb747e27f2ccfd88f38655fb8bb378192d6dc4c  # [win]
+    sha256: dd29b7f92f48dead4dd940492c7509138c0f99db445076d0a597007298a79940  # [win]
 
   - url: https://ffmpeg.zeranoe.com/builds/win64/dev/ffmpeg-{{ version_ffmpeg_style }}-win64-dev.zip  # [win]
-    sha256: 019a81f79ef88f8465a807f8fa2a416836810d7775a933cbde519e2eff69ead9  # [win]
+    sha256: 2e8038242cf8e1bd095c2978f196ff0462b122cc6ef7e74626a6af15459d8b81  # [win]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: ffmpeg
-  version: {{ version_ffmpeg_style }}
+  version: {{ version }}
 
 source:
   - url: https://ffmpeg.org/releases/ffmpeg-{{ version_ffmpeg_style }}.tar.gz  # [not win]


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
This is a fix of #87, because it didn't enable auto-update unfortunately. 
Once this PR is merged, there will be a difference between the FFmpeg versioning and the versioning of this package (only when patch version equals zero); however, I don't think manual updating is sustainable.
I'll leave the decision to the maintainers.
