### PR TITLE
V4.4.x lgpl clang and nvidia encoders

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,16 +8,28 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_license_familygpl:
+        CONFIG: linux_64_license_familygpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_:
-        CONFIG: linux_aarch64_
+      linux_64_license_familylgpl:
+        CONFIG: linux_64_license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_ppc64le_:
-        CONFIG: linux_ppc64le_
+      linux_aarch64_license_familygpl:
+        CONFIG: linux_aarch64_license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_license_familylgpl:
+        CONFIG: linux_aarch64_license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_license_familygpl:
+        CONFIG: linux_ppc64le_license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_ppc64le_license_familylgpl:
+        CONFIG: linux_ppc64le_license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,11 +8,17 @@ jobs:
     vmImage: macOS-10.15
   strategy:
     matrix:
-      osx_64_:
-        CONFIG: osx_64_
+      osx_64_license_familygpl:
+        CONFIG: osx_64_license_familygpl
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_:
-        CONFIG: osx_arm64_
+      osx_64_license_familylgpl:
+        CONFIG: osx_64_license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_license_familygpl:
+        CONFIG: osx_arm64_license_familygpl
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_license_familylgpl:
+        CONFIG: osx_arm64_license_familylgpl
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
 

--- a/.ci_support/linux_64_license_familygpl.yaml
+++ b/.ci_support/linux_64_license_familygpl.yaml
@@ -1,31 +1,31 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '13'
+- '10'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '13'
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 freetype:
 - '2'
 gmp:
 - '6'
 gnutls:
 - '3.7'
-libiconv:
-- '1.16'
 libxml2:
 - '2.9'
-macos_machine:
-- arm64-apple-darwin20.0.0
+license_family:
+- gpl
 pin_run_as_build:
   bzip2:
     max_pin: x
@@ -33,8 +33,6 @@ pin_run_as_build:
     max_pin: x
   gmp:
     max_pin: x
-  libiconv:
-    max_pin: x.x
   libxml2:
     max_pin: x.x
   zlib:
@@ -42,7 +40,7 @@ pin_run_as_build:
 svt_av1:
 - 1.1.0
 target_platform:
-- osx-arm64
+- linux-64
 x264:
 - 1!161.*
 x265:

--- a/.ci_support/linux_64_license_familylgpl.yaml
+++ b/.ci_support/linux_64_license_familylgpl.yaml
@@ -1,0 +1,52 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos6
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+freetype:
+- '2'
+gmp:
+- '6'
+gnutls:
+- '3.7'
+libxml2:
+- '2.9'
+license_family:
+- lgpl
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gmp:
+    max_pin: x
+  libxml2:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+svt_av1:
+- 1.1.0
+target_platform:
+- linux-64
+x264:
+- 1!161.*
+x265:
+- '3.5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/linux_aarch64_license_familygpl.yaml
+++ b/.ci_support/linux_aarch64_license_familygpl.yaml
@@ -1,9 +1,13 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 bzip2:
 - '1'
 c_compiler:
 - gcc
 c_compiler_version:
 - '10'
+cdt_arch:
+- aarch64
 cdt_name:
 - cos7
 channel_sources:
@@ -24,6 +28,8 @@ gnutls:
 - '3.7'
 libxml2:
 - '2.9'
+license_family:
+- gpl
 pin_run_as_build:
   bzip2:
     max_pin: x
@@ -38,7 +44,7 @@ pin_run_as_build:
 svt_av1:
 - 1.1.0
 target_platform:
-- linux-ppc64le
+- linux-aarch64
 x264:
 - 1!161.*
 x265:

--- a/.ci_support/linux_aarch64_license_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_license_familylgpl.yaml
@@ -1,0 +1,56 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+freetype:
+- '2'
+gmp:
+- '6'
+gnutls:
+- '3.7'
+libxml2:
+- '2.9'
+license_family:
+- lgpl
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gmp:
+    max_pin: x
+  libxml2:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+svt_av1:
+- 1.1.0
+target_platform:
+- linux-aarch64
+x264:
+- 1!161.*
+x265:
+- '3.5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/linux_ppc64le_license_familygpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familygpl.yaml
@@ -1,0 +1,52 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+freetype:
+- '2'
+gmp:
+- '6'
+gnutls:
+- '3.7'
+libxml2:
+- '2.9'
+license_family:
+- gpl
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gmp:
+    max_pin: x
+  libxml2:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+svt_av1:
+- 1.1.0
+target_platform:
+- linux-ppc64le
+x264:
+- 1!161.*
+x265:
+- '3.5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/linux_ppc64le_license_familylgpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familylgpl.yaml
@@ -1,0 +1,52 @@
+bzip2:
+- '1'
+c_compiler:
+- gcc
+c_compiler_version:
+- '10'
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '10'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+freetype:
+- '2'
+gmp:
+- '6'
+gnutls:
+- '3.7'
+libxml2:
+- '2.9'
+license_family:
+- lgpl
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gmp:
+    max_pin: x
+  libxml2:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+svt_av1:
+- 1.1.0
+target_platform:
+- linux-ppc64le
+x264:
+- 1!161.*
+x265:
+- '3.5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_64_license_familygpl.yaml
+++ b/.ci_support/osx_64_license_familygpl.yaml
@@ -1,33 +1,33 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '10'
-cdt_arch:
-- aarch64
-cdt_name:
-- cos7
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '10'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '13'
 freetype:
 - '2'
 gmp:
 - '6'
 gnutls:
 - '3.7'
+libiconv:
+- '1.16'
 libxml2:
 - '2.9'
+license_family:
+- gpl
+macos_machine:
+- x86_64-apple-darwin13.4.0
 pin_run_as_build:
   bzip2:
     max_pin: x
@@ -35,6 +35,8 @@ pin_run_as_build:
     max_pin: x
   gmp:
     max_pin: x
+  libiconv:
+    max_pin: x.x
   libxml2:
     max_pin: x.x
   zlib:
@@ -42,7 +44,7 @@ pin_run_as_build:
 svt_av1:
 - 1.1.0
 target_platform:
-- linux-aarch64
+- osx-64
 x264:
 - 1!161.*
 x265:

--- a/.ci_support/osx_64_license_familylgpl.yaml
+++ b/.ci_support/osx_64_license_familylgpl.yaml
@@ -1,0 +1,56 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
+bzip2:
+- '1'
+c_compiler:
+- clang
+c_compiler_version:
+- '13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '13'
+freetype:
+- '2'
+gmp:
+- '6'
+gnutls:
+- '3.7'
+libiconv:
+- '1.16'
+libxml2:
+- '2.9'
+license_family:
+- lgpl
+macos_machine:
+- x86_64-apple-darwin13.4.0
+pin_run_as_build:
+  bzip2:
+    max_pin: x
+  freetype:
+    max_pin: x
+  gmp:
+    max_pin: x
+  libiconv:
+    max_pin: x.x
+  libxml2:
+    max_pin: x.x
+  zlib:
+    max_pin: x.x
+svt_av1:
+- 1.1.0
+target_platform:
+- osx-64
+x264:
+- 1!161.*
+x265:
+- '3.5'
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+zlib:
+- '1.2'

--- a/.ci_support/osx_arm64_license_familygpl.yaml
+++ b/.ci_support/osx_arm64_license_familygpl.yaml
@@ -1,29 +1,33 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 bzip2:
 - '1'
 c_compiler:
-- gcc
+- clang
 c_compiler_version:
-- '10'
-cdt_name:
-- cos6
+- '13'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '10'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '13'
 freetype:
 - '2'
 gmp:
 - '6'
 gnutls:
 - '3.7'
+libiconv:
+- '1.16'
 libxml2:
 - '2.9'
+license_family:
+- gpl
+macos_machine:
+- arm64-apple-darwin20.0.0
 pin_run_as_build:
   bzip2:
     max_pin: x
@@ -31,6 +35,8 @@ pin_run_as_build:
     max_pin: x
   gmp:
     max_pin: x
+  libiconv:
+    max_pin: x.x
   libxml2:
     max_pin: x.x
   zlib:
@@ -38,7 +44,7 @@ pin_run_as_build:
 svt_av1:
 - 1.1.0
 target_platform:
-- linux-64
+- osx-arm64
 x264:
 - 1!161.*
 x265:

--- a/.ci_support/osx_arm64_license_familylgpl.yaml
+++ b/.ci_support/osx_arm64_license_familylgpl.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '11.0'
 bzip2:
 - '1'
 c_compiler:
@@ -24,8 +24,10 @@ libiconv:
 - '1.16'
 libxml2:
 - '2.9'
+license_family:
+- lgpl
 macos_machine:
-- x86_64-apple-darwin13.4.0
+- arm64-apple-darwin20.0.0
 pin_run_as_build:
   bzip2:
     max_pin: x
@@ -42,7 +44,7 @@ pin_run_as_build:
 svt_av1:
 - 1.1.0
 target_platform:
-- osx-64
+- osx-arm64
 x264:
 - 1!161.*
 x265:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About ffmpeg
 
 Home: http://www.ffmpeg.org/
 
-Package license: GPL-3.0-or-later
+Package license: GPL-2.0-or-later
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/ffmpeg-feedstock/blob/master/LICENSE.txt)
 
@@ -31,38 +31,73 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_64_license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64</td>
+              <td>linux_64_license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_64_license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_ppc64le</td>
+              <td>linux_aarch64_license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64</td>
+              <td>linux_aarch64_license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=osx&configuration=osx_64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_aarch64_license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_arm64</td>
+              <td>linux_ppc64le_license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_ppc64le_license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=linux&configuration=linux_ppc64le_license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=osx&configuration=osx_64_license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=osx&configuration=osx_64_license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=master">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=master&jobName=osx&configuration=osx_arm64_license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,12 +23,25 @@ if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
   EXTRA_CONFIGURE_OPTIONS="--enable-cross-compile --arch=$ARCH --target-os=$OS --cross-prefix=$HOST- --host-cc=$CC_FOR_BUILD"
 fi
 
+extra_args=""
 if [[ "${target_platform}" == "linux-64" ]]; then
-  extra_codecs=--enable-vaapi
+  extra_args=--enable-vaapi
 elif [[ "${target_platform}" == osx-* ]]; then
+  if [[ "${target_platform}" == osx-arm64 ]]; then
+    extra_args="${extra_args} --enable-neon"
+  else
+    extra_args="${extra_args} --disable-videotoolbox"
+  fi
+
   # See https://github.com/conda-forge/ffmpeg-feedstock/pull/115
   # why this flag needs to be removed.
   sed -i.bak s/-Wl,-single_module// configure
+fi
+
+if [[ "${license_family}" == "gpl" ]]; then
+    extra_args="${extra_args} --enable-gpl --enable-libx264 --enable-libx265"
+else
+    extra_args="${extra_args} --disable-gpl"
 fi
 
 ./configure \
@@ -36,16 +49,12 @@ fi
         --cc=${CC} \
         --disable-doc \
         --disable-openssl \
-        --enable-avresample \
         --enable-demuxer=dash \
         --enable-gnutls \
-        --enable-gpl \
         --enable-hardcoded-tables \
         --enable-libfreetype \
         --enable-libopenh264 \
-        ${extra_codecs} \
-        --enable-libx264 \
-        --enable-libx265 \
+        ${extra_args} \
         --enable-libaom \
         --enable-libsvtav1 \
         --enable-libxml2 \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,7 @@ set -ex
 
 # unset the SUBDIR variable since it changes the behavior of make here
 unset SUBDIR
+cuda_compiler_version=${cuda_compiler_version:-None}
 
 if [[ "$CONDA_BUILD_CROSS_COMPILATION" == "1" ]]; then
   if [[ "$ARCH" == "64" ]]; then
@@ -25,7 +26,8 @@ fi
 
 extra_args=""
 if [[ "${target_platform}" == "linux-64" ]]; then
-  extra_args=--enable-vaapi
+  extra_args="${extra_args} --enable-vaapi"
+
 elif [[ "${target_platform}" == osx-* ]]; then
   if [[ "${target_platform}" == osx-arm64 ]]; then
     extra_args="${extra_args} --enable-neon"
@@ -37,7 +39,6 @@ elif [[ "${target_platform}" == osx-* ]]; then
   # why this flag needs to be removed.
   sed -i.bak s/-Wl,-single_module// configure
 fi
-
 if [[ "${license_family}" == "gpl" ]]; then
     extra_args="${extra_args} --enable-gpl --enable-libx264 --enable-libx265"
 else
@@ -47,8 +48,10 @@ fi
 ./configure \
         --prefix="${PREFIX}" \
         --cc=${CC} \
+        --cxx=${CXX} \
         --disable-doc \
         --disable-openssl \
+        --enable-avresample \
         --enable-demuxer=dash \
         --enable-gnutls \
         --enable-hardcoded-tables \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+license_family:
+  - gpl
+  - lgpl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,14 @@ source:
   patches:
     - patches/TARGET_OS_OSX.patch     # [osx]
 
+{%- set number = 1 %}
+{%- if license_family == 'gpl' %}
+{%- set number = number + 100 %}
+{%- endif %}
 
 build:
-  number: 0
+  number: {{ number }}
+  string: {{ license_family }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   run_exports:
   # seems to be major version compatibility
   # https://abi-laboratory.pro/tracker/timeline/ffmpeg/
@@ -38,8 +43,10 @@ requirements:
     - gnutls  # [not win]
     - libiconv  # [osx]
     - libxml2  # [not win]
+    {% if license_family == 'gpl' %}
     - x264  # [not win]
     - x265  # [not win]
+    {% endif %}
     - libvpx  # [not win]
     - zlib  # [not win]
     - openh264  # [not win]
@@ -56,8 +63,6 @@ test:
     - ffmpeg -loglevel panic -codecs | grep "libmp3lame"  # [not win]
     - ffmpeg -loglevel panic -codecs | grep "DEVI.S zlib"  # [unix]
     - ffmpeg -loglevel panic -codecs | grep "DEV.LS h264"  # [unix]
-    - ffmpeg -loglevel panic -codecs | grep "libx264"  # [unix]
-    - ffmpeg -loglevel panic -codecs | grep "libx265"  # [unix]
     - ffmpeg -loglevel panic -codecs | grep "libopenh264"  # [unix]
     - ffmpeg -loglevel panic -codecs | grep "vaapi"  # [linux and not (ppc64le or aarch64)]
     - ffmpeg -loglevel panic -codecs | grep "libaom"  # [unix]
@@ -66,7 +71,6 @@ test:
     {% set ffmpeg_libs = [
         "avdevice",
         "swresample",
-        "postproc",
         "avfilter",
         "avcodec",
         "avformat",
@@ -77,11 +81,30 @@ test:
     {% for each_ffmpeg_lib in ffmpeg_libs %}
     - test -f $PREFIX/lib/lib{{ each_ffmpeg_lib }}${SHLIB_EXT}  # [unix]
     {% endfor %}
+    {%- if license_family == 'gpl' %}
+    - ffmpeg -hide_banner -buildconf | grep "enable-gpl"  # [unix]
+    - ffmpeg -loglevel panic -codecs | grep "libx264"     # [unix]
+    - ffmpeg -loglevel panic -codecs | grep "libx265"     # [unix]
+    - test -f $PREFIX/lib/libpostproc${SHLIB_EXT}         # [unix]
+    {%- endif %}
+    {%- if license_family == 'lgpl' %}
+    - ffmpeg -hide_banner -buildconf | grep "disable-gpl"        # [unix]
+    - test ! $(ffmpeg -loglevel panic -codecs | grep "libx264")  # [unix]
+    - test ! $(ffmpeg -loglevel panic -codecs | grep "libx265")  # [unix]
+    - test ! -f $PREFIX/lib/libpostproc${SHLIB_EXT}              # [unix]
+    {%- endif %}
 
 about:
   home: http://www.ffmpeg.org/
-  license: GPL-3.0-or-later
-  license_file: COPYING.GPLv3  # [unix]
+  license: GPL-2.0-or-later     # [license_family=='gpl']
+  license: LGPL-2.1-or-later    # [license_family=='lgpl']
+  license_file:
+    - COPYING.GPLv2            # [license_family=='gpl']
+    - COPYING.GPLv3            # [license_family=='gpl']
+    - COPYING.LGPLv2.1         # [license_family=='lgpl']
+    - COPYING.LGPLv3           # [license_family=='lgpl']
+  license_family: GPL          # [license_family=='gpl']
+  license_family: LGPL         # [license_family=='lgpl']
   summary: Cross-platform solution to record, convert and stream audio and video.
   dev_url: https://git.ffmpeg.org/ffmpeg.git
   doc_url: https://ffmpeg.org/documentation.html

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 {%- set number = 1 %}
 {%- if license_family == 'gpl' %}
-{%- set number = number + 100 %}
+{%- set number = number + 200 %}
 {%- endif %}
 
 build:
@@ -30,6 +30,8 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    # clangxx is required for support of the nvidia encoders and decoders
+    - clangxx  # [linux64]
     - pkg-config  # [not win]
     - libtool  # [not win]
     - nasm  # [not (win or (osx and x86_64))]
@@ -55,6 +57,7 @@ requirements:
     - libva  # [linux and not (ppc64le or aarch64)]
     - aom  # [unix]
     - svt-av1  # [unix]
+    - ffnvcodec-headers  # [linux64]
 
 test:
   commands:
@@ -93,6 +96,23 @@ test:
     - test ! $(ffmpeg -loglevel panic -codecs | grep "libx265")  # [unix]
     - test ! -f $PREFIX/lib/libpostproc${SHLIB_EXT}              # [unix]
     {%- endif %}
+    # Verify nvidia codecs on linux
+    {% set nvcodecs = [
+        "nvenc",
+        "h264_nvenc",
+        "hevc_nvenc",
+        "mjpeg_cuvid",
+        "mpeg1_cuvid",
+        "mpeg2_cuvid",
+        "mpeg4_cuvid",
+        "vc1_cuvid",
+        "vp8_cuvid",
+        "vp9_cuvid"
+    ] %}
+    {% for nvcodec in nvcodecs %}
+    # Make sure to include a space in there to ensure we get an exact match
+    - ffmpeg -hide_banner -codecs | grep " {{ nvcodec }} "  # [linux64]
+    {% endfor %}
 
 about:
   home: http://www.ffmpeg.org/


### PR DESCRIPTION
This is the way that ubuntu packages things.

I studied their configuration https://packages.ubuntu.com/jammy/ffmpeg and added clang.

ffmpeg then autodetects clang and builds support for nvidia encoders

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
