### PR TITLE
Libxml2.10 5.x

### DIFF
--- a/.ci_support/linux_64_license_familygpl.yaml
+++ b/.ci_support/linux_64_license_familygpl.yaml
@@ -27,7 +27,7 @@ gmp:
 gnutls:
 - '3.7'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/linux_64_license_familylgpl.yaml
+++ b/.ci_support/linux_64_license_familylgpl.yaml
@@ -27,7 +27,7 @@ gmp:
 gnutls:
 - '3.7'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - lgpl
 openh264:

--- a/.ci_support/linux_aarch64_license_familygpl.yaml
+++ b/.ci_support/linux_aarch64_license_familygpl.yaml
@@ -31,7 +31,7 @@ gmp:
 gnutls:
 - '3.7'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/linux_aarch64_license_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_license_familylgpl.yaml
@@ -31,7 +31,7 @@ gmp:
 gnutls:
 - '3.7'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - lgpl
 openh264:

--- a/.ci_support/linux_ppc64le_license_familygpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familygpl.yaml
@@ -27,7 +27,7 @@ gmp:
 gnutls:
 - '3.7'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/linux_ppc64le_license_familylgpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familylgpl.yaml
@@ -27,7 +27,7 @@ gmp:
 gnutls:
 - '3.7'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - lgpl
 openh264:

--- a/.ci_support/migrations/libxml2210.yaml
+++ b/.ci_support/migrations/libxml2210.yaml
@@ -1,0 +1,7 @@
+__migrator:
+  build_number: 1
+  kind: version
+  migration_number: 1
+libxml2:
+- '2.10'
+migrator_ts: 1660820650.179783

--- a/.ci_support/migrations/svt_av1130.yaml
+++ b/.ci_support/migrations/svt_av1130.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-migrator_ts: 1666290111.7187
-svt_av1:
-- 1.3.0

--- a/.ci_support/osx_64_license_familygpl.yaml
+++ b/.ci_support/osx_64_license_familygpl.yaml
@@ -27,7 +27,7 @@ gnutls:
 libiconv:
 - '1'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - gpl
 macos_machine:

--- a/.ci_support/osx_64_license_familylgpl.yaml
+++ b/.ci_support/osx_64_license_familylgpl.yaml
@@ -27,7 +27,7 @@ gnutls:
 libiconv:
 - '1'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - lgpl
 macos_machine:

--- a/.ci_support/osx_arm64_license_familygpl.yaml
+++ b/.ci_support/osx_arm64_license_familygpl.yaml
@@ -27,7 +27,7 @@ gnutls:
 libiconv:
 - '1'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - gpl
 macos_machine:

--- a/.ci_support/osx_arm64_license_familylgpl.yaml
+++ b/.ci_support/osx_arm64_license_familylgpl.yaml
@@ -27,7 +27,7 @@ gnutls:
 libiconv:
 - '1'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - lgpl
 macos_machine:

--- a/.ci_support/win_64_license_familygpl.yaml
+++ b/.ci_support/win_64_license_familygpl.yaml
@@ -15,7 +15,7 @@ fontconfig:
 freetype:
 - '2'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/win_64_license_familylgpl.yaml
+++ b/.ci_support/win_64_license_familylgpl.yaml
@@ -15,7 +15,7 @@ fontconfig:
 freetype:
 - '2'
 libxml2:
-- '2.9'
+- '2.10'
 license_family:
 - lgpl
 openh264:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About ffmpeg
 
 Home: https://www.ffmpeg.org/
 
-Package license: LGPL-2.1-or-later
+Package license: GPL-2.0-or-later
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/ffmpeg-feedstock/blob/main/LICENSE.txt)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   patches:
     - patches/pkgconfig_generate_windows_llvm.patch  # [win]
 
-{% set build = 2 %}
+{% set build = 3 %}
 {% if license_family == 'gpl' %}
     {% set build = build + 100 %}
 {% endif %}


### PR DESCRIPTION
libxml2 2.9 and 2.10 are ABI compatible, so we skipped through most of the migration. However, this is somewhat causing issues with ffmpeg that was recently rebuilt before the pinning was changed.

I'm running these manually to help alleviate issues while

* https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3543

or

* https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/3542

is chosen


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
