### PR TITLE
Enable videotoolbox on osx

### DIFF
--- a/.ci_support/osx_64_license_familygpl.yaml
+++ b/.ci_support/osx_64_license_familygpl.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 aom:
 - '3.8'
 bzip2:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.9'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/osx_64_license_familylgpl.yaml
+++ b/.ci_support/osx_64_license_familylgpl.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+- '10.13'
 aom:
 - '3.8'
 bzip2:
@@ -11,7 +11,7 @@ c_compiler_version:
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
-- '10.9'
+- '10.13'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_license_familygpl.yaml
+++ b/.ci_support/win_64_license_familygpl.yaml
@@ -6,6 +6,8 @@ c_compiler:
 - vs2019
 c_stdlib:
 - vs
+c_stdlib_version:
+- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/.ci_support/win_64_license_familylgpl.yaml
+++ b/.ci_support/win_64_license_familylgpl.yaml
@@ -6,6 +6,8 @@ c_compiler:
 - vs2019
 c_stdlib:
 - vs
+c_stdlib_version:
+- '2019'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ About ffmpeg
 
 Home: https://www.ffmpeg.org/
 
-Package license: LGPL-2.1-or-later
+Package license: GPL-2.0-or-later
 
 Summary: Cross-platform solution to record, convert and stream audio and video.
 
@@ -22,7 +22,7 @@ About ffmpeg
 
 Home: https://www.ffmpeg.org/
 
-Package license: GPL-2.0-or-later
+Package license: LGPL-2.1-or-later
 
 Summary: Cross-platform solution to record, convert and stream audio and video.
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -89,7 +89,7 @@ elif [[ "${target_platform}" == osx-* ]]; then
   if [[ "${target_platform}" == osx-arm64 ]]; then
     extra_args="${extra_args} --enable-neon"
   else
-    extra_args="${extra_args} --disable-videotoolbox"
+    extra_args="${extra_args} --enable-videotoolbox"
   fi
   extra_args="${extra_args} --enable-gnutls"
   extra_args="${extra_args} --enable-libmp3lame"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,5 @@
 license_family:
   - lgpl
   - gpl
+c_stdlib_version:   # [osx and x86_64]
+  - "10.13"         # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ requirements:
   build:
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
+    - {{ stdlib("c") }}  # [osx and x86_64]
     # clangxx is required for support of the nvidia encoders and decoders
     - clangxx  # [linux64]
     - autotools_clang_conda  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     # needed for qtwebengine
     - patches/add-av_stream_get_first_dts-for-chromium.patch
 
-{% set build = 7 %}
+{% set build = 8 %}
 {% if license_family == 'gpl' %}
     {% set build = build + 100 %}
 {% endif %}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This is needed for using ffmpeg as the backend for Qt Multimedia for Qt 6.7: https://github.com/conda-forge/qt-main-feedstock/pull/256.

Addresses #241, but mostly curious in figuring out whether videotoolbox can be re-enabled.