### PR TITLE
Build out matrix for cuda (ffmpeg7)

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,20 +8,44 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_license_familygpl:
-        CONFIG: linux_64_license_familygpl
+      linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl:
+        CONFIG: linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_license_familylgpl:
-        CONFIG: linux_64_license_familylgpl
+      linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl:
+        CONFIG: linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_license_familygpl:
-        CONFIG: linux_aarch64_license_familygpl
+      linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl:
+        CONFIG: linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_aarch64_license_familylgpl:
-        CONFIG: linux_aarch64_license_familylgpl
+      linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl:
+        CONFIG: linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl:
+        CONFIG: linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl:
+        CONFIG: linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl:
+        CONFIG: linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl:
+        CONFIG: linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl:
+        CONFIG: linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl:
+        CONFIG: linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_ppc64le_license_familygpl:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,11 +8,23 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_license_familygpl:
-        CONFIG: win_64_license_familygpl
+      win_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl:
+        CONFIG: win_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl
         UPLOAD_PACKAGES: 'True'
-      win_64_license_familylgpl:
-        CONFIG: win_64_license_familylgpl
+      win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl:
+        CONFIG: win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl
+        UPLOAD_PACKAGES: 'True'
+      win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl:
+        CONFIG: win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl
+        UPLOAD_PACKAGES: 'True'
+      win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl:
+        CONFIG: win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+      win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl:
+        CONFIG: win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl
+        UPLOAD_PACKAGES: 'True'
+      win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl:
+        CONFIG: win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
@@ -1,7 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 aom:
 - '3.9'
 build_number_increment:
@@ -9,23 +5,29 @@ build_number_increment:
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- None
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 ffnvcodec_headers:
 - None
 fontconfig:
@@ -42,12 +44,12 @@ libiconv:
 - '1'
 libopenvino_dev:
 - 2024.4.0
+libxcb:
+- '1.16'
 libxml2:
 - '2'
 license_family:
 - gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +57,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- linux-64
 x264:
 - 1!164.*
 x265:
@@ -65,7 +67,10 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
@@ -1,7 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 aom:
 - '3.9'
 build_number_increment:
@@ -9,23 +5,29 @@ build_number_increment:
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- None
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 ffnvcodec_headers:
 - None
 fontconfig:
@@ -42,12 +44,12 @@ libiconv:
 - '1'
 libopenvino_dev:
 - 2024.4.0
+libxcb:
+- '1.16'
 libxml2:
 - '2'
 license_family:
-- gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
+- lgpl
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +57,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- linux-64
 x264:
 - 1!164.*
 x265:
@@ -65,7 +67,10 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl.yaml
@@ -1,5 +1,7 @@
 aom:
 - '3.9'
+build_number_increment:
+- '400'
 bzip2:
 - '1'
 c_compiler:
@@ -16,6 +18,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -24,6 +28,8 @@ dav1d:
 - 1.2.1
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+ffnvcodec_headers:
+- 12.1.14
 fontconfig:
 - '2'
 freetype:
@@ -63,5 +69,8 @@ zip_keys:
   - cxx_compiler_version
 - - c_stdlib_version
   - cdt_name
+- - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl.yaml
@@ -1,33 +1,35 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '400'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.2'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 ffnvcodec_headers:
-- None
+- 12.1.14
 fontconfig:
 - '2'
 freetype:
@@ -42,12 +44,12 @@ libiconv:
 - '1'
 libopenvino_dev:
 - 2024.4.0
+libxcb:
+- '1.16'
 libxml2:
 - '2'
 license_family:
-- gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
+- lgpl
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +57,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- linux-64
 x264:
 - 1!164.*
 x265:
@@ -65,7 +67,10 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
@@ -1,5 +1,7 @@
 aom:
 - '3.9'
+build_number_increment:
+- '600'
 bzip2:
 - '1'
 c_compiler:
@@ -16,6 +18,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -24,6 +28,8 @@ dav1d:
 - 1.2.1
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+ffnvcodec_headers:
+- 12.2.72
 fontconfig:
 - '2'
 freetype:
@@ -43,7 +49,7 @@ libxcb:
 libxml2:
 - '2'
 license_family:
-- lgpl
+- gpl
 openh264:
 - 2.4.1
 openssl:
@@ -63,5 +69,8 @@ zip_keys:
   - cxx_compiler_version
 - - c_stdlib_version
   - cdt_name
+- - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
@@ -1,7 +1,7 @@
-BUILD:
-- aarch64-conda_cos7-linux-gnu
 aom:
 - '3.9'
+build_number_increment:
+- '600'
 bzip2:
 - '1'
 c_compiler:
@@ -12,14 +12,14 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_arch:
-- aarch64
 cdt_name:
 - cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -28,6 +28,8 @@ dav1d:
 - 1.2.1
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+ffnvcodec_headers:
+- 12.2.72
 fontconfig:
 - '2'
 freetype:
@@ -55,7 +57,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- linux-aarch64
+- linux-64
 x264:
 - 1!164.*
 x265:
@@ -67,5 +69,8 @@ zip_keys:
   - cxx_compiler_version
 - - c_stdlib_version
   - cdt_name
+- - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
@@ -1,7 +1,5 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 aom:
 - '3.9'
 build_number_increment:
@@ -9,23 +7,31 @@ build_number_increment:
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- None
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 ffnvcodec_headers:
 - None
 fontconfig:
@@ -42,12 +48,12 @@ libiconv:
 - '1'
 libopenvino_dev:
 - 2024.4.0
+libxcb:
+- '1.16'
 libxml2:
 - '2'
 license_family:
 - gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +61,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- linux-aarch64
 x264:
 - 1!164.*
 x265:
@@ -65,7 +71,10 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
@@ -1,7 +1,5 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 aom:
 - '3.9'
 build_number_increment:
@@ -9,23 +7,31 @@ build_number_increment:
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- None
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 ffnvcodec_headers:
 - None
 fontconfig:
@@ -42,12 +48,12 @@ libiconv:
 - '1'
 libopenvino_dev:
 - 2024.4.0
+libxcb:
+- '1.16'
 libxml2:
 - '2'
 license_family:
-- gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
+- lgpl
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +61,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- linux-aarch64
 x264:
 - 1!164.*
 x265:
@@ -65,7 +71,10 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
@@ -2,6 +2,8 @@ BUILD:
 - aarch64-conda_cos7-linux-gnu
 aom:
 - '3.9'
+build_number_increment:
+- '600'
 bzip2:
 - '1'
 c_compiler:
@@ -20,6 +22,8 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -28,6 +32,8 @@ dav1d:
 - 1.2.1
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+ffnvcodec_headers:
+- 12.2.72
 fontconfig:
 - '2'
 freetype:
@@ -67,5 +73,8 @@ zip_keys:
   - cxx_compiler_version
 - - c_stdlib_version
   - cdt_name
+- - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
@@ -1,33 +1,39 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '600'
 bzip2:
 - '1'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '17'
+- '13'
 c_stdlib:
-- macosx_deployment_target
+- sysroot
 c_stdlib_version:
-- '11.0'
+- '2.17'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.4'
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '17'
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 ffnvcodec_headers:
-- None
+- 12.2.72
 fontconfig:
 - '2'
 freetype:
@@ -42,12 +48,12 @@ libiconv:
 - '1'
 libopenvino_dev:
 - 2024.4.0
+libxcb:
+- '1.16'
 libxml2:
 - '2'
 license_family:
-- gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
+- lgpl
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +61,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- linux-aarch64
 x264:
 - 1!164.*
 x265:
@@ -65,7 +71,10 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_license_familygpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familygpl.yaml
@@ -1,5 +1,7 @@
 aom:
 - '3.9'
+build_number_increment:
+- '0'
 bzip2:
 - '1'
 c_compiler:
@@ -24,6 +26,8 @@ dav1d:
 - 1.2.1
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+ffnvcodec_headers:
+- None
 fontconfig:
 - '2'
 freetype:
@@ -61,5 +65,7 @@ zip_keys:
   - cxx_compiler_version
 - - c_stdlib_version
   - cdt_name
+- - ffnvcodec_headers
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/linux_ppc64le_license_familylgpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familylgpl.yaml
@@ -1,5 +1,7 @@
 aom:
 - '3.9'
+build_number_increment:
+- '0'
 bzip2:
 - '1'
 c_compiler:
@@ -24,6 +26,8 @@ dav1d:
 - 1.2.1
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+ffnvcodec_headers:
+- None
 fontconfig:
 - '2'
 freetype:
@@ -61,5 +65,7 @@ zip_keys:
   - cxx_compiler_version
 - - c_stdlib_version
   - cdt_name
+- - ffnvcodec_headers
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/osx_64_license_familygpl.yaml
+++ b/.ci_support/osx_64_license_familygpl.yaml
@@ -4,6 +4,8 @@ MACOSX_SDK_VERSION:
 - '10.13'
 aom:
 - '3.9'
+build_number_increment:
+- '0'
 bzip2:
 - '1'
 c_compiler:
@@ -24,6 +26,8 @@ cxx_compiler_version:
 - '17'
 dav1d:
 - 1.2.1
+ffnvcodec_headers:
+- None
 fontconfig:
 - '2'
 freetype:
@@ -61,5 +65,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - ffnvcodec_headers
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/osx_64_license_familylgpl.yaml
+++ b/.ci_support/osx_64_license_familylgpl.yaml
@@ -4,6 +4,8 @@ MACOSX_SDK_VERSION:
 - '10.13'
 aom:
 - '3.9'
+build_number_increment:
+- '0'
 bzip2:
 - '1'
 c_compiler:
@@ -24,6 +26,8 @@ cxx_compiler_version:
 - '17'
 dav1d:
 - 1.2.1
+ffnvcodec_headers:
+- None
 fontconfig:
 - '2'
 freetype:
@@ -61,5 +65,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - ffnvcodec_headers
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/osx_arm64_license_familylgpl.yaml
+++ b/.ci_support/osx_arm64_license_familylgpl.yaml
@@ -4,6 +4,8 @@ MACOSX_SDK_VERSION:
 - '11.0'
 aom:
 - '3.9'
+build_number_increment:
+- '0'
 bzip2:
 - '1'
 c_compiler:
@@ -24,6 +26,8 @@ cxx_compiler_version:
 - '17'
 dav1d:
 - 1.2.1
+ffnvcodec_headers:
+- None
 fontconfig:
 - '2'
 freetype:
@@ -61,5 +65,7 @@ xz:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - ffnvcodec_headers
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/win_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
+++ b/.ci_support/win_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
@@ -1,7 +1,3 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 aom:
 - '3.9'
 build_number_increment:
@@ -9,21 +5,17 @@ build_number_increment:
 bzip2:
 - '1'
 c_compiler:
-- clang
-c_compiler_version:
-- '17'
+- vs2019
 c_stdlib:
-- macosx_deployment_target
-c_stdlib_version:
-- '11.0'
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- None
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '17'
+- vs2019
 dav1d:
 - 1.2.1
 ffnvcodec_headers:
@@ -34,20 +26,14 @@ freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
 - '9'
 libiconv:
 - '1'
-libopenvino_dev:
-- 2024.4.0
 libxml2:
 - '2'
 license_family:
 - gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +41,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- win-64
 x264:
 - 1!164.*
 x265:
@@ -63,9 +49,8 @@ x265:
 xz:
 - '5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
+++ b/.ci_support/win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
@@ -1,5 +1,7 @@
 aom:
 - '3.9'
+build_number_increment:
+- '0'
 bzip2:
 - '1'
 c_compiler:
@@ -10,10 +12,14 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- None
 cxx_compiler:
 - vs2019
 dav1d:
 - 1.2.1
+ffnvcodec_headers:
+- None
 fontconfig:
 - '2'
 freetype:
@@ -42,5 +48,9 @@ x265:
 - '3.5'
 xz:
 - '5'
+zip_keys:
+- - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl.yaml
+++ b/.ci_support/win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl.yaml
@@ -1,53 +1,39 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '400'
 bzip2:
 - '1'
 c_compiler:
-- clang
-c_compiler_version:
-- '17'
+- vs2019
 c_stdlib:
-- macosx_deployment_target
-c_stdlib_version:
-- '11.0'
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.2'
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '17'
+- vs2019
 dav1d:
 - 1.2.1
 ffnvcodec_headers:
-- None
+- 12.1.14
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
 - '9'
 libiconv:
 - '1'
-libopenvino_dev:
-- 2024.4.0
 libxml2:
 - '2'
 license_family:
 - gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +41,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- win-64
 x264:
 - 1!164.*
 x265:
@@ -63,9 +49,8 @@ x265:
 xz:
 - '5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl.yaml
+++ b/.ci_support/win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl.yaml
@@ -1,53 +1,39 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '400'
 bzip2:
 - '1'
 c_compiler:
-- clang
-c_compiler_version:
-- '17'
+- vs2019
 c_stdlib:
-- macosx_deployment_target
-c_stdlib_version:
-- '11.0'
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.2'
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '17'
+- vs2019
 dav1d:
 - 1.2.1
 ffnvcodec_headers:
-- None
+- 12.1.14
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
 - '9'
 libiconv:
 - '1'
-libopenvino_dev:
-- 2024.4.0
 libxml2:
 - '2'
 license_family:
-- gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
+- lgpl
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +41,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- win-64
 x264:
 - 1!164.*
 x265:
@@ -63,9 +49,8 @@ x265:
 xz:
 - '5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
+++ b/.ci_support/win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
@@ -1,5 +1,7 @@
 aom:
 - '3.9'
+build_number_increment:
+- '600'
 bzip2:
 - '1'
 c_compiler:
@@ -10,10 +12,14 @@ channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.4'
 cxx_compiler:
 - vs2019
 dav1d:
 - 1.2.1
+ffnvcodec_headers:
+- 12.2.72
 fontconfig:
 - '2'
 freetype:
@@ -42,5 +48,9 @@ x265:
 - '3.5'
 xz:
 - '5'
+zip_keys:
+- - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
+  - build_number_increment
 zlib:
 - '1'

--- a/.ci_support/win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
+++ b/.ci_support/win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
@@ -1,53 +1,39 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
-MACOSX_SDK_VERSION:
-- '11.0'
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '600'
 bzip2:
 - '1'
 c_compiler:
-- clang
-c_compiler_version:
-- '17'
+- vs2019
 c_stdlib:
-- macosx_deployment_target
-c_stdlib_version:
-- '11.0'
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
+cuda_version_for_ffnvcodec:
+- '12.4'
 cxx_compiler:
-- clangxx
-cxx_compiler_version:
-- '17'
+- vs2019
 dav1d:
 - 1.2.1
 ffnvcodec_headers:
-- None
+- 12.2.72
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
 - '9'
 libiconv:
 - '1'
-libopenvino_dev:
-- 2024.4.0
 libxml2:
 - '2'
 license_family:
-- gpl
-macos_machine:
-- arm64-apple-darwin20.0.0
+- lgpl
 openh264:
 - 2.4.1
 openssl:
@@ -55,7 +41,7 @@ openssl:
 svt_av1:
 - 2.2.1
 target_platform:
-- osx-arm64
+- win-64
 x264:
 - 1!164.*
 x265:
@@ -63,9 +49,8 @@ x265:
 xz:
 - '5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
+  - cuda_version_for_ffnvcodec
   - build_number_increment
 zlib:
 - '1'

--- a/README.md
+++ b/README.md
@@ -48,31 +48,73 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_license_familygpl</td>
+              <td>linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_license_familygpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_license_familylgpl</td>
+              <td>linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_license_familylgpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_license_familygpl</td>
+              <td>linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_license_familygpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_license_familylgpl</td>
+              <td>linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_license_familylgpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -118,17 +160,45 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_license_familygpl</td>
+              <td>win_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_license_familygpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_license_familylgpl</td>
+              <td>win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_license_familylgpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,50 @@
 license_family:
   - lgpl
   - gpl
+
+# hmaarrfk
+# These could be wrong, but I'm not too sure how to find an exact correspondance
+# between the cuda version and the nvidia driver version
+# I think they could technically be out of sync
+# To find the compatibility version of ffnvcodec_headers, you can look at the
+# https://github.com/FFmpeg/nv-codec-headers/tree/n12.0.16.1
+# To find the __cuda version I:
+# Uninstall all nvidia driver from ubuntu
+# Installed a specific version they offered
+# rebooted
+# Checked what was reported by conda info
+# sudo apt remove *nvidia*
+# sudo apt install nvidia-driver-470
+# sudo reboot
+# conda info | grep cuda
+# I checked the following versions
+#     - nvidia-driver-550 -- cuda 12.4
+#     - nvidia-driver-535 -- cuda 12.2
+#     - nvidia-driver-530 -- seems to install 535...
+#     - nvidia-driver-525 -- seems to install 535...
+#     - nvidia-driver-520 -- seems to install 535...
+#     - nvidia-driver-515 -- seems to install 535...
+#     - nvidia-driver-510 -- seems to install 535...
+#     - nvidia-driver-470 -- Did not work on my machine (likely GPU too new)
+cuda_version_for_ffnvcodec:
+  - None
+  - 12.2                       # [linux64 or win]
+  - 12.4                       # [linux64 or win or aarch64]
+
+ffnvcodec_headers:
+  - None
+  - 12.1.14                    # [linux64 or win]
+  - 12.2.72                    # [linux64 or win or aarch64]
+
+# Build increment of 100 is used for lgpl/gpl builds
+build_number_increment:
+  - 0
+  # 200 is reserved for something compatible with 11.8
+  # but .... it would require adjusting the tests
+  - 400                        # [linux64 or win]
+  - 600                        # [linux64 or win or aarch64]
+
+zip_keys:
+  - - ffnvcodec_headers
+    - cuda_version_for_ffnvcodec
+    - build_number_increment

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,9 +23,20 @@ source:
     # Include time_internal header for windows to correctly locate localtime_r and gmtime_r
     - patches/include_time_internal_header.patch
 
-{% set build = 4 %}
+{% set build = 5 %}
 {% if license_family == 'gpl' %}
     {% set build = build + 100 %}
+{% endif %}
+
+# Can't seem to get int + str to add without this...
+{% if build_number_increment == '200' %}
+    {% set build = build + 200 %}
+{% endif %}
+{% if build_number_increment == '400' %}
+    {% set build = build + 400 %}
+{% endif %}
+{% if build_number_increment == '600' %}
+    {% set build = build + 600 %}
 {% endif %}
 
 build:
@@ -79,7 +90,7 @@ requirements:
     - libva  # [linux64]
     - aom
     - svt-av1
-    - ffnvcodec-headers  # [linux64 or win]
+    - ffnvcodec-headers  {{ ffnvcodec_headers }}  # [ffnvcodec_headers != "None"]
     - libopus
     - libopenvino-dev    # [not ppc64le and not win]
     - libass  # [not win]
@@ -87,6 +98,8 @@ requirements:
     - xz
     - libxcb       # [linux]
     - xorg-libx11  # [linux]
+  run_constrained:
+    - __cuda  >={{ cuda_version_for_ffnvcodec }}  # [ffnvcodec_headers != "None"]
 
 {% set grep = "grep" %}  # [unix]
 {% set grep = "findstr" %}  # [win]
@@ -165,7 +178,7 @@ test:
         "vp9_cuvid"
     ] %}
     {% for nvcodec in nvcodecs %}
-    - ffmpeg -hide_banner -codecs | {{ grep }} "{{ nvcodec }}"  # [linux64 or win]
+    - ffmpeg -hide_banner -codecs | {{ grep }} "{{ nvcodec }}"  # [ffnvcodec_headers != "None"]
     {% endfor %}
     # https://trac.ffmpeg.org/wiki/Null
     - ffmpeg -hide_banner -f lavfi -i nullsrc=s=256x256:d=8 -vcodec libopenh264 -f null -


### PR DESCRIPTION
I've noticed that nvcodec doesn't work for 535

I don't have a good way of detecting the nvidia driver version, so i'm using `__cuda` as a proxy.

Closes https://github.com/conda-forge/ffmpeg-feedstock/issues/205


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
