### PR TITLE
Enable alsa and pulse devices on Linux and ffplay commands on all platforms

### DIFF
--- a/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -62,6 +64,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_ppc64le_license_familygpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familygpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -58,6 +60,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/linux_ppc64le_license_familylgpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familylgpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -58,6 +60,8 @@ openh264:
 - 2.5.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 svt_av1:
 - 2.3.0
 target_platform:

--- a/.ci_support/migrations/harfbuzz10.yaml
+++ b/.ci_support/migrations/harfbuzz10.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for harfbuzz 10
-  kind: version
-  migration_number: 1
-harfbuzz:
-- '10'
-migrator_ts: 1733714243.4949675

--- a/.ci_support/migrations/openvino202460.yaml
+++ b/.ci_support/migrations/openvino202460.yaml
@@ -1,7 +1,0 @@
-migrator_ts: 1735564861
-__migrator:
-  kind: version
-  migration_number: 1
-  bump_number: 1
-libopenvino_dev:
-  - 2024.6.0

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -156,6 +156,7 @@ fi
         --enable-zlib \
         --enable-libopus \
 	--enable-librsvg \
+         --enable-ffplay \
         --pkg-config=${PKG_CONFIG} \
         || { if [[ ${CI} != "" ]]; then cat ffbuild/config.log; fi; exit 1; }
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -82,6 +82,8 @@ elif [[ "${target_platform}" == linux-* ]]; then
   extra_args="${extra_args} --enable-libvpx"
   extra_args="${extra_args} --enable-libass"
   extra_args="${extra_args} --enable-pthreads"
+  extra_args="${extra_args} --enable-alsa"
+  extra_args="${extra_args} --enable-libpulse"
   if [[ "${target_platform}" == "linux-64" ]]; then
     extra_args="${extra_args} --enable-vaapi"
   fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -131,7 +131,7 @@ test:
     - ffmpeg -hide_banner -codecs | {{ grep }} "libaom"
     - ffmpeg -hide_banner -codecs | {{ grep }} "libsvtav1"
     # Verify ffplay is available
-    - ffplag -version
+    - ffplay -version
     # Verify dynamic libraries on all systems
     {% set ffmpeg_libs = [
         "avdevice",

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
     # Include time_internal header for windows to correctly locate localtime_r and gmtime_r
     - patches/include_time_internal_header.patch
 
-{% set build = 9 %}
+{% set build = 10 %}
 {% if license_family == 'gpl' %}
     {% set build = build + 100 %}
 {% endif %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,6 +102,8 @@ requirements:
     - libxcb             # [linux]
     - xorg-libx11        # [linux]
     - xorg-xorgproto     # [linux]
+    - alsa-lib           # [linux]
+    - pulseaudio         # [linux]
   run_constrained:
     - __cuda  >={{ cuda_version_for_ffnvcodec }}  # [ffnvcodec_headers != "None"]
 
@@ -194,6 +196,9 @@ test:
     {% endfor %}
     # https://trac.ffmpeg.org/wiki/Null
     - ffmpeg -hide_banner -f lavfi -i nullsrc=s=256x256:d=8 -vcodec libopenh264 -f null -
+    # Verify required devices on linux
+    - ffmpeg -hide_banner -devices | grep "alsa"  # [linux]
+    - ffmpeg -hide_banner -devices | grep "pulse"  # [linux]
 
 about:
   home: https://www.ffmpeg.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,7 @@ requirements:
     - xorg-libx11        # [linux]
     - xorg-xorgproto     # [linux]
     - alsa-lib           # [linux]
-    - pulseaudio         # [linux]
+    - pulseaudio-client  # [linux]
   run_constrained:
     - __cuda  >={{ cuda_version_for_ffnvcodec }}  # [ffnvcodec_headers != "None"]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -99,6 +99,7 @@ requirements:
     - libopenvino-dev    # [not win and not ppc64le]
     - dav1d
     - liblzma-devel
+    - sdl2
     - libxcb             # [linux]
     - xorg-libx11        # [linux]
     - xorg-xorgproto     # [linux]
@@ -129,6 +130,8 @@ test:
     - ffmpeg -hide_banner -codecs | {{ grep }} "vaapi"            # [linux64]
     - ffmpeg -hide_banner -codecs | {{ grep }} "libaom"
     - ffmpeg -hide_banner -codecs | {{ grep }} "libsvtav1"
+    # Verify ffplay is available
+    - ffplag -version
     # Verify dynamic libraries on all systems
     {% set ffmpeg_libs = [
         "avdevice",


### PR DESCRIPTION
A team in our organization (fyi @S-Dafarra @giotherobot) was struggling in acquiring real time audio using the `ffmpeg` packages on conda-forge, while everything was working fine when working with the `ffmpeg` packaged by Debian/Ubuntu on apt. It turns out the `alsa-lib` and `pulseaudio-client` libraries were not enabled in conda-forge's ffmpeg (as you can easily see by running `ffmpeg -hide_banner -devices` , so this PR enable the compilation of these devices on Linux, and verify that they have been correctly enabled.

As both dependencies have a `LGPL-2.1-or-later` license, I enabled them for both `lgpl` and `gpl` builds.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
