### PR TITLE
BLD: Expand build matrix to more video codec sdks

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,20 +16,28 @@ jobs:
         CONFIG: linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl:
-        CONFIG: linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl
+      linux_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl:
+        CONFIG: linux_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl:
-        CONFIG: linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl
+      linux_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl:
+        CONFIG: linux_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl:
-        CONFIG: linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl
+      linux_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl:
+        CONFIG: linux_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl:
-        CONFIG: linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl
+      linux_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl:
+        CONFIG: linux_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl:
+        CONFIG: linux_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl:
+        CONFIG: linux_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl:
@@ -40,12 +48,20 @@ jobs:
         CONFIG: linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl:
-        CONFIG: linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl
+      linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familygpl:
+        CONFIG: linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familygpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
-      linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl:
-        CONFIG: linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl
+      linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl:
+        CONFIG: linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familygpl:
+        CONFIG: linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familygpl
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+      linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl:
+        CONFIG: linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
       linux_ppc64le_license_familygpl:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -14,17 +14,23 @@ jobs:
       win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl:
         CONFIG: win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl
         UPLOAD_PACKAGES: 'True'
-      win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl:
-        CONFIG: win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl
+      win_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl:
+        CONFIG: win_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl
         UPLOAD_PACKAGES: 'True'
-      win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl:
-        CONFIG: win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl
+      win_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl:
+        CONFIG: win_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl
         UPLOAD_PACKAGES: 'True'
-      win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl:
-        CONFIG: win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl
+      win_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl:
+        CONFIG: win_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl
         UPLOAD_PACKAGES: 'True'
-      win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl:
-        CONFIG: win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl
+      win_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl:
+        CONFIG: win_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl
+        UPLOAD_PACKAGES: 'True'
+      win_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl:
+        CONFIG: win_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl
+        UPLOAD_PACKAGES: 'True'
+      win_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl:
+        CONFIG: win_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl
         UPLOAD_PACKAGES: 'True'
   timeoutInMinutes: 360
   variables:

--- a/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
@@ -45,7 +45,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -57,7 +57,7 @@ librsvg:
 libxcb:
 - '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
@@ -45,7 +45,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -57,7 +57,7 @@ librsvg:
 libxcb:
 - '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - lgpl
 openh264:

--- a/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl.yaml
@@ -3,7 +3,7 @@ alsa_lib:
 aom:
 - '3.9'
 build_number_increment:
-- '600'
+- '400'
 bzip2:
 - '1'
 c_compiler:
@@ -21,7 +21,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- '12.4'
+- '12.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -35,7 +35,7 @@ expat:
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.2.72
+- 12.1.*
 fontconfig:
 - '2'
 freetype:
@@ -45,7 +45,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -57,7 +57,7 @@ librsvg:
 libxcb:
 - '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl.yaml
@@ -3,7 +3,7 @@ alsa_lib:
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '400'
 bzip2:
 - '1'
 c_compiler:
@@ -21,7 +21,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- None
+- '12.2'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -35,7 +35,7 @@ expat:
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- None
+- 12.1.*
 fontconfig:
 - '2'
 freetype:
@@ -71,7 +71,7 @@ sdl2:
 svt_av1:
 - 3.0.2
 target_platform:
-- linux-aarch64
+- linux-64
 x264:
 - 1!164.*
 x265:

--- a/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl.yaml
@@ -1,3 +1,5 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -5,9 +7,15 @@ build_number_increment:
 bzip2:
 - '1'
 c_compiler:
-- vs2019
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
-- vs
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,48 +23,62 @@ channel_targets:
 cuda_version_for_ffnvcodec:
 - '12.4'
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.2.72
+- 12.2.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
+gmp:
+- '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
+libopenvino_dev:
+- 2025.0.0
 librsvg:
 - '2'
+libxcb:
+- '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- win-64
+- linux-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl.yaml
@@ -3,7 +3,7 @@ alsa_lib:
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '600'
 bzip2:
 - '1'
 c_compiler:
@@ -21,7 +21,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- None
+- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -35,7 +35,7 @@ expat:
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- None
+- 12.2.*
 fontconfig:
 - '2'
 freetype:
@@ -71,7 +71,7 @@ sdl2:
 svt_av1:
 - 3.0.2
 target_platform:
-- linux-aarch64
+- linux-64
 x264:
 - 1!164.*
 x265:

--- a/.ci_support/linux_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl.yaml
+++ b/.ci_support/linux_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl.yaml
@@ -1,62 +1,84 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
-- '400'
+- '800'
 bzip2:
 - '1'
 c_compiler:
-- vs2019
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
-- vs
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- '12.2'
+- '12.8'
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.1.14
+- 13.0.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
+gmp:
+- '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
+libopenvino_dev:
+- 2025.0.0
 librsvg:
 - '2'
+libxcb:
+- '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- win-64
+- linux-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/linux_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl.yaml
+++ b/.ci_support/linux_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl.yaml
@@ -1,62 +1,84 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
-- '600'
+- '800'
 bzip2:
 - '1'
 c_compiler:
-- vs2019
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
-- vs
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- '12.4'
+- '12.8'
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.2.72
+- 13.0.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
+gmp:
+- '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
+libopenvino_dev:
+- 2025.0.0
 librsvg:
 - '2'
+libxcb:
+- '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - lgpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- win-64
+- linux-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
@@ -45,7 +45,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -57,7 +57,7 @@ librsvg:
 libxcb:
 - '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familygpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familygpl.yaml
@@ -3,7 +3,7 @@ alsa_lib:
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '600'
 bzip2:
 - '1'
 c_compiler:
@@ -21,7 +21,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- None
+- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -35,7 +35,7 @@ expat:
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- None
+- 12.2.*
 fontconfig:
 - '2'
 freetype:
@@ -59,7 +59,7 @@ libxcb:
 libxml2:
 - '2.13'
 license_family:
-- lgpl
+- gpl
 openh264:
 - 2.6.0
 openssl:

--- a/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl.yaml
@@ -3,7 +3,7 @@ alsa_lib:
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '600'
 bzip2:
 - '1'
 c_compiler:
@@ -21,7 +21,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- None
+- '12.4'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -35,7 +35,7 @@ expat:
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- None
+- 12.2.*
 fontconfig:
 - '2'
 freetype:

--- a/.ci_support/linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familygpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familygpl.yaml
@@ -1,62 +1,84 @@
+alsa_lib:
+- '1.2'
 aom:
 - '3.9'
 build_number_increment:
-- '400'
+- '800'
 bzip2:
 - '1'
 c_compiler:
-- vs2019
+- gcc
+c_compiler_version:
+- '13'
 c_stdlib:
-- vs
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_name:
+- conda
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- '12.2'
+- '12.8'
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '13'
 dav1d:
 - 1.2.1
+docker_image:
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.1.14
+- 13.0.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
+gmp:
+- '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
+libopenvino_dev:
+- 2025.0.0
 librsvg:
 - '2'
+libxcb:
+- '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
-- lgpl
+- gpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
+pulseaudio_client:
+- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- win-64
+- linux-aarch64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl.yaml
+++ b/.ci_support/linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl.yaml
@@ -3,7 +3,7 @@ alsa_lib:
 aom:
 - '3.9'
 build_number_increment:
-- '600'
+- '800'
 bzip2:
 - '1'
 c_compiler:
@@ -21,7 +21,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- '12.4'
+- '12.8'
 cxx_compiler:
 - gxx
 cxx_compiler_version:
@@ -35,7 +35,7 @@ expat:
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.2.72
+- 13.0.*
 fontconfig:
 - '2'
 freetype:
@@ -45,7 +45,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -57,9 +57,9 @@ librsvg:
 libxcb:
 - '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
-- gpl
+- lgpl
 openh264:
 - 2.6.0
 openssl:

--- a/.ci_support/linux_ppc64le_license_familygpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familygpl.yaml
@@ -43,7 +43,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -53,7 +53,7 @@ librsvg:
 libxcb:
 - '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/linux_ppc64le_license_familylgpl.yaml
+++ b/.ci_support/linux_ppc64le_license_familylgpl.yaml
@@ -43,7 +43,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -53,7 +53,7 @@ librsvg:
 libxcb:
 - '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - lgpl
 openh264:

--- a/.ci_support/osx_64_license_familygpl.yaml
+++ b/.ci_support/osx_64_license_familygpl.yaml
@@ -41,7 +41,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -51,7 +51,7 @@ libopenvino_dev:
 librsvg:
 - '2'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 macos_machine:

--- a/.ci_support/osx_64_license_familylgpl.yaml
+++ b/.ci_support/osx_64_license_familylgpl.yaml
@@ -41,7 +41,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -51,7 +51,7 @@ libopenvino_dev:
 librsvg:
 - '2'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - lgpl
 macos_machine:

--- a/.ci_support/osx_arm64_license_familygpl.yaml
+++ b/.ci_support/osx_arm64_license_familygpl.yaml
@@ -41,7 +41,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -51,7 +51,7 @@ libopenvino_dev:
 librsvg:
 - '2'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 macos_machine:

--- a/.ci_support/osx_arm64_license_familylgpl.yaml
+++ b/.ci_support/osx_arm64_license_familylgpl.yaml
@@ -41,7 +41,7 @@ glib:
 gmp:
 - '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -51,7 +51,7 @@ libopenvino_dev:
 librsvg:
 - '2'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - lgpl
 macos_machine:

--- a/.ci_support/win_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
+++ b/.ci_support/win_64_build_number_increment0ffnvcodec_headersNonelicense_familygpl.yaml
@@ -31,7 +31,7 @@ freetype:
 glib:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -39,7 +39,7 @@ liblzma_devel:
 librsvg:
 - '2'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - gpl
 openh264:

--- a/.ci_support/win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
+++ b/.ci_support/win_64_build_number_increment0ffnvcodec_headersNonelicense_familylgpl.yaml
@@ -31,7 +31,7 @@ freetype:
 glib:
 - '2'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
@@ -39,7 +39,7 @@ liblzma_devel:
 librsvg:
 - '2'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - lgpl
 openh264:

--- a/.ci_support/win_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl.yaml
+++ b/.ci_support/win_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl.yaml
@@ -1,84 +1,62 @@
-alsa_lib:
-- '1.2'
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '400'
 bzip2:
 - '1'
 c_compiler:
-- gcc
-c_compiler_version:
-- '13'
+- vs2019
 c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- None
+- '12.2'
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '13'
+- vs2019
 dav1d:
 - 1.2.1
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- None
+- 12.1.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
 - 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
-libopenvino_dev:
-- 2025.0.0
 librsvg:
 - '2'
-libxcb:
-- '1'
 libxml2:
 - '2.13'
 license_family:
-- lgpl
+- gpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
-pulseaudio_client:
-- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- linux-aarch64
+- win-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/win_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl.yaml
+++ b/.ci_support/win_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl.yaml
@@ -1,5 +1,3 @@
-alsa_lib:
-- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -7,15 +5,9 @@ build_number_increment:
 bzip2:
 - '1'
 c_compiler:
-- gcc
-c_compiler_version:
-- '13'
+- vs2019
 c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
@@ -23,62 +15,48 @@ channel_targets:
 cuda_version_for_ffnvcodec:
 - '12.2'
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '13'
+- vs2019
 dav1d:
 - 1.2.1
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.1.14
+- 12.1.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
-libopenvino_dev:
-- 2025.0.0
 librsvg:
 - '2'
-libxcb:
-- '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
-- gpl
+- lgpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
-pulseaudio_client:
-- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- linux-64
+- win-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/win_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl.yaml
+++ b/.ci_support/win_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl.yaml
@@ -1,84 +1,62 @@
-alsa_lib:
-- '1.2'
 aom:
 - '3.9'
 build_number_increment:
-- '0'
+- '600'
 bzip2:
 - '1'
 c_compiler:
-- gcc
-c_compiler_version:
-- '13'
+- vs2019
 c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- None
+- '12.5'
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '13'
+- vs2019
 dav1d:
 - 1.2.1
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- None
+- 12.2.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
 - 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
-libopenvino_dev:
-- 2025.0.0
 librsvg:
 - '2'
-libxcb:
-- '1'
 libxml2:
 - '2.13'
 license_family:
-- lgpl
+- gpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
-pulseaudio_client:
-- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- linux-aarch64
+- win-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/win_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl.yaml
+++ b/.ci_support/win_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl.yaml
@@ -1,5 +1,3 @@
-alsa_lib:
-- '1.2'
 aom:
 - '3.9'
 build_number_increment:
@@ -7,78 +5,58 @@ build_number_increment:
 bzip2:
 - '1'
 c_compiler:
-- gcc
-c_compiler_version:
-- '13'
+- vs2019
 c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- '12.4'
+- '12.5'
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '13'
+- vs2019
 dav1d:
 - 1.2.1
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.2.72
+- 12.2.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
-libopenvino_dev:
-- 2025.0.0
 librsvg:
 - '2'
-libxcb:
-- '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - lgpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
-pulseaudio_client:
-- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- linux-64
+- win-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/win_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl.yaml
+++ b/.ci_support/win_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl.yaml
@@ -1,84 +1,62 @@
-alsa_lib:
-- '1.2'
 aom:
 - '3.9'
 build_number_increment:
-- '600'
+- '800'
 bzip2:
 - '1'
 c_compiler:
-- gcc
-c_compiler_version:
-- '13'
+- vs2019
 c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- '12.4'
+- '12.8'
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '13'
+- vs2019
 dav1d:
 - 1.2.1
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.2.72
+- 13.0.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
-libopenvino_dev:
-- 2025.0.0
 librsvg:
 - '2'
-libxcb:
-- '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
-- lgpl
+- gpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
-pulseaudio_client:
-- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- linux-aarch64
+- win-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.ci_support/win_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl.yaml
+++ b/.ci_support/win_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl.yaml
@@ -1,84 +1,62 @@
-alsa_lib:
-- '1.2'
 aom:
 - '3.9'
 build_number_increment:
-- '400'
+- '800'
 bzip2:
 - '1'
 c_compiler:
-- gcc
-c_compiler_version:
-- '13'
+- vs2019
 c_stdlib:
-- sysroot
-c_stdlib_version:
-- '2.17'
-cdt_name:
-- conda
+- vs
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cuda_version_for_ffnvcodec:
-- '12.2'
+- '12.8'
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '13'
+- vs2019
 dav1d:
 - 1.2.1
-docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
 expat:
 - '2'
 ffmpeg:
 - '7'
 ffnvcodec_headers:
-- 12.1.14
+- 13.0.*
 fontconfig:
 - '2'
 freetype:
 - '2'
 glib:
 - '2'
-gmp:
-- '6'
 harfbuzz:
-- '11'
+- 11.0.1
 libiconv:
 - '1'
 liblzma_devel:
 - '5'
-libopenvino_dev:
-- 2025.0.0
 librsvg:
 - '2'
-libxcb:
-- '1'
 libxml2:
-- '2'
+- '2.13'
 license_family:
 - lgpl
 openh264:
 - 2.6.0
 openssl:
 - '3'
-pulseaudio_client:
-- '17.0'
 sdl2:
 - '2'
 svt_av1:
 - 3.0.2
 target_platform:
-- linux-64
+- win-64
 x264:
 - 1!164.*
 x265:
 - '3.5'
 zip_keys:
-- - c_compiler_version
-  - cxx_compiler_version
 - - ffnvcodec_headers
   - cuda_version_for_ffnvcodec
   - build_number_increment

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -12,7 +12,7 @@ source .scripts/logging_utils.sh
 set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
-PROVIDER_DIR="$(basename $THISDIR)"
+PROVIDER_DIR="$(basename "$THISDIR")"
 
 FEEDSTOCK_ROOT="$( cd "$( dirname "$0" )/.." >/dev/null && pwd )"
 RECIPE_ROOT="${FEEDSTOCK_ROOT}/recipe"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -25,7 +25,7 @@ set "MICROMAMBA_EXE=%MICROMAMBA_TMPDIR%\micromamba.exe"
 
 echo Downloading micromamba %MICROMAMBA_VERSION%
 if not exist "%MICROMAMBA_TMPDIR%" mkdir "%MICROMAMBA_TMPDIR%"
-certutil -urlcache -split -f "%MICROMAMBA_URL%" "%MICROMAMBA_EXE%"
+powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('%MICROMAMBA_URL%', '%MICROMAMBA_EXE%')"
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 echo Creating environment

--- a/README.md
+++ b/README.md
@@ -62,31 +62,45 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl</td>
+              <td>linux_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl</td>
+              <td>linux_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl</td>
+              <td>linux_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl</td>
+              <td>linux_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -104,17 +118,31 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl</td>
+              <td>linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl</td>
+              <td>linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -174,31 +202,45 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl</td>
+              <td>win_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment400ffnvcodec_headers12.1.14license_familygpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment400ffnvcodec_headers12.1._license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl</td>
+              <td>win_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment400ffnvcodec_headers12.1.14license_familylgpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment400ffnvcodec_headers12.1._license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl</td>
+              <td>win_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment600ffnvcodec_headers12.2.72license_familygpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment600ffnvcodec_headers12.2._license_familygpl" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl</td>
+              <td>win_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment600ffnvcodec_headers12.2.72license_familylgpl" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment600ffnvcodec_headers12.2._license_familylgpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment800ffnvcodec_headers13.0._license_familygpl" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=5418&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ffmpeg-feedstock?branchName=main&jobName=win&configuration=win%20win_64_build_number_increment800ffnvcodec_headers13.0._license_familylgpl" alt="variant">
                 </a>
               </td>
             </tr>

--- a/build-locally.py
+++ b/build-locally.py
@@ -10,6 +10,7 @@ import glob
 import os
 import platform
 import subprocess
+import sys
 from argparse import ArgumentParser
 
 
@@ -44,10 +45,19 @@ def run_osx_build(ns):
     subprocess.check_call([script])
 
 
+def run_win_build(ns):
+    script = ".scripts/run_win_build.bat"
+    subprocess.check_call(["cmd", "/D", "/Q", "/C", f"CALL {script}"])
+
+
 def verify_config(ns):
+    choices_filter = ns.filter or "*"
     valid_configs = {
-        os.path.basename(f)[:-5] for f in glob.glob(".ci_support/*.yaml")
+        os.path.basename(f)[:-5]
+        for f in glob.glob(f".ci_support/{choices_filter}.yaml")
     }
+    if choices_filter != "*":
+        print(f"filtering for '{choices_filter}.yaml' configs")
     print(f"valid configs are {valid_configs}")
     if ns.config in valid_configs:
         print("Using " + ns.config + " configuration")
@@ -60,30 +70,37 @@ def verify_config(ns):
         selections = list(enumerate(sorted(valid_configs), 1))
         for i, c in selections:
             print(f"{i}. {c}")
-        s = input("\n> ")
+        try:
+            s = input("\n> ")
+        except KeyboardInterrupt:
+            print("\nno option selected, bye!", file=sys.stderr)
+            sys.exit(1)
         idx = int(s) - 1
         ns.config = selections[idx][1]
         print(f"selected {ns.config}")
     else:
         raise ValueError("config " + ns.config + " is not valid")
-    # Remove the following, as implemented
-    if ns.config.startswith("win"):
-        raise ValueError(
-            f"only Linux/macOS configs currently supported, got {ns.config}"
+    if (
+        ns.config.startswith("osx")
+        and platform.system() == "Darwin"
+        and not os.environ.get("OSX_SDK_DIR")
+    ):
+        raise RuntimeError(
+            "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+            "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+            "Note: OSX_SDK_DIR must be set to an absolute path. "
+            "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
         )
-    elif ns.config.startswith("osx"):
-        if "OSX_SDK_DIR" not in os.environ:
-            raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
-                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
-                "Note: OSX_SDK_DIR must be set to an absolute path. "
-                "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
-            )
 
 
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--filter",
+        default=None,
+        help="Glob string to filter which build choices are presented in interactive mode.",
+    )
     p.add_argument(
         "--debug",
         action="store_true",
@@ -104,6 +121,8 @@ def main(args=None):
             run_docker_build(ns)
         elif ns.config.startswith("osx"):
             run_osx_build(ns)
+        elif ns.config.startswith("win"):
+            run_win_build(ns)
     finally:
         recipe_license_file = os.path.join(
             "recipe", "recipe-scripts-license.txt"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -2,39 +2,28 @@ license_family:
   - lgpl
   - gpl
 
-# hmaarrfk
-# These could be wrong, but I'm not too sure how to find an exact correspondance
-# between the cuda version and the nvidia driver version
-# I think they could technically be out of sync
-# To find the compatibility version of ffnvcodec_headers, you can look at the
-# https://github.com/FFmpeg/nv-codec-headers/tree/n12.0.16.1
-# To find the __cuda version I:
-# Uninstall all nvidia driver from ubuntu
-# Installed a specific version they offered
-# rebooted
-# Checked what was reported by conda info
-# sudo apt remove *nvidia*
-# sudo apt install nvidia-driver-470
-# sudo reboot
-# conda info | grep cuda
-# I checked the following versions
-#     - nvidia-driver-550 -- cuda 12.4
-#     - nvidia-driver-535 -- cuda 12.2
-#     - nvidia-driver-530 -- seems to install 535...
-#     - nvidia-driver-525 -- seems to install 535...
-#     - nvidia-driver-520 -- seems to install 535...
-#     - nvidia-driver-515 -- seems to install 535...
-#     - nvidia-driver-510 -- seems to install 535...
-#     - nvidia-driver-470 -- Did not work on my machine (likely GPU too new)
+# See this issue for mapping between CTK version and video codec SDK version
+# https://github.com/conda-forge/ffmpeg-feedstock/issues/288
 cuda_version_for_ffnvcodec:
   - None
-  - 12.2                       # [linux64 or win]
-  - 12.4                       # [linux64 or win or aarch64]
+  # - 11.5                       # [linux64]
+  # - 11.8                       # [linux64]
+  - 12.2                       # [linux64]
+  - 12.4                       # [linux64 or aarch64]
+  - 12.8                       # [linux64 or aarch64]
+  # - 11.5                       # [win]
+  # - 12.0                       # [win]
+  - 12.2                       # [win]
+  - 12.5                       # [win]
+  - 12.8                       # [win]
 
 ffnvcodec_headers:
   - None
-  - 12.1.14                    # [linux64 or win]
-  - 12.2.72                    # [linux64 or win or aarch64]
+  # - 11.1.*                    # [linux64 or win]
+  # - 12.0.*                    # [linux64 or win]
+  - 12.1.*                    # [linux64 or win]
+  - 12.2.*                    # [linux64 or win or aarch64]
+  - 13.0.*                    # [linux64 or win or aarch64]
 
 # Build increment of 100 is used for lgpl/gpl builds
 build_number_increment:
@@ -43,6 +32,7 @@ build_number_increment:
   # but .... it would require adjusting the tests
   - 400                        # [linux64 or win]
   - 600                        # [linux64 or win or aarch64]
+  - 800                        # [linux64 or win or aarch64]
 
 zip_keys:                               # [linux64 or win or aarch64]
   - - ffnvcodec_headers                 # [linux64 or win or aarch64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,20 +27,10 @@ source:
     # https://code.ffmpeg.org/FFmpeg/FFmpeg/pulls/12
     - patches/12-svtav1_300_support.patch
 
-{% set build = 4 %}
+{% set build = 5 %}
+{% set build = build | int + build_number_increment | int %}
 {% if license_family == 'gpl' %}
     {% set build = build + 100 %}
-{% endif %}
-
-# Can't seem to get int + str to add without this...
-{% if build_number_increment == '200' %}
-    {% set build = build + 200 %}
-{% endif %}
-{% if build_number_increment == '400' %}
-    {% set build = build + 400 %}
-{% endif %}
-{% if build_number_increment == '600' %}
-    {% set build = build + 600 %}
 {% endif %}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,8 @@
 {% set version = "7.1.1" %} # semver: (x.y.z)
 {% set x,y,z = version.split('.') %}
 {% set version_ffmpeg_style = x ~ '.' ~ y if z == "0" else version %}
+{% set build_number_increment = build_number_increment | default(0) %}
+{% set license_family = license_family | default("lgpl") %}
 
 package:
   name: ffmpeg


### PR DESCRIPTION
Expands the build matrix with a newer version of the ffmpeg headers for the NVIDIA video codec SDK.

Does not add a build compatible with CTK11 users because I don't know enough about this project of adjust the tests. The appropriate pinnings are added to the conda_build_config.yaml for anyone who's interested.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Closes https://github.com/conda-forge/ffmpeg-feedstock/issues/288
