### PR TITLE
Rebuild with shaderc 2026.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ source:
     # hmaarrfk -- not sure why i need this one. need to report upstream
     - patches/0006-Use-forward-lahs-on-windows.patch
 
-{% set build = 0 %}
+{% set build = 1 %}
 {% set build = build | int + build_number_increment | int %}
 {% if license_family == 'gpl' %}
     {% set build = build + 100 %}


### PR DESCRIPTION
See the first point in https://github.com/conda-forge/conda-forge-pinning-feedstock/issues/8450 . While a recent build of ffmpeg was done, it used an old shaderc as libplacebo was requiring it, but this is now fixed thanks to https://github.com/conda-forge/libplacebo-feedstock/pull/9 .


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
