### PR TITLE
Patch nvenc double free on encoder init failure

### DIFF
--- a/.ci_support/migrations/shaderc20263.yaml
+++ b/.ci_support/migrations/shaderc20263.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for shaderc 2026.3
-  kind: version
-  migration_number: 1
-migrator_ts: 1784260216.2971818
-shaderc:
-- '2026.3'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,14 @@ source:
     # hmaarrfk -- not sure why i need this one. need to report upstream
     - patches/0006-Use-forward-lahs-on-windows.patch
 
-{% set build = 4 %}
+    # nvenc aborts the process instead of failing cleanly when
+    # nvEncCreateBitstreamBuffer() fails during encoder init: the input buffer
+    # is destroyed on the error path but the handle is left dangling, and
+    # ff_nvenc_encode_close() then destroys it a second time.
+    # https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/24019
+    - patches/0007-avcodec-nvenc-fix-double-free-of-the-input-buffer.patch
+
+{% set build = 5 %}
 {% set build = build | int + build_number_increment | int %}
 {% if license_family == 'gpl' %}
     {% set build = build + 100 %}

--- a/recipe/patches/0007-avcodec-nvenc-fix-double-free-of-the-input-buffer.patch
+++ b/recipe/patches/0007-avcodec-nvenc-fix-double-free-of-the-input-buffer.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mark Harfouche <mark.harfouche@gmail.com>
+Date: Wed, 5 Aug 2026 11:17:40 -0400
+Subject: [PATCH] avcodec/nvenc: fix double free of the input buffer on the
+ alloc_surface error path
+
+nvenc_alloc_surface() destroys the input buffer it just created when
+nvEncCreateBitstreamBuffer() fails, but leaves ctx->surfaces[idx].input_surface
+pointing at the destroyed handle. All three nvenc encoders set
+FF_CODEC_CAP_INIT_CLEANUP, so a failed ff_nvenc_encode_init() is followed by
+ff_nvenc_encode_close(), which loops over every surface and calls
+nvEncDestroyInputBuffer() on that same handle a second time. The driver frees a
+host-heap object there, so glibc aborts the process instead of ffmpeg exiting
+with an error.
+
+Also skip the NULL handles left in ctx->surfaces[] for surfaces past the failing
+one. ctx->surfaces is av_calloc'd, so those entries are NULL and were being
+handed straight to the driver.
+
+Reproducer, needs only H.264 NVENC:
+
+    ffmpeg -f lavfi -i nullsrc=s=4096x4096 -frames:v 1 \
+           -vcodec h264_nvenc -surfaces 64 -f null -
+    [h264_nvenc] CreateBitstreamBuffer failed: out of memory (10):
+    free(): invalid pointer
+    -> SIGABRT (rc 134)
+
+4096x4096 is H.264 NVENC's largest picture and 64 is MAX_REGISTERED_FRAMES, so
+the request exceeds the driver's per-session bitstream-buffer budget and
+nvEncCreateBitstreamBuffer() legitimately fails. With this applied the same
+command reports the error and exits with AVERROR(ENOMEM).
+
+Upstream report: https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/24019
+---
+ libavcodec/nvenc.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/libavcodec/nvenc.c b/libavcodec/nvenc.c
+index 5eab67a1fe..775e064ca1 100644
+--- a/libavcodec/nvenc.c
++++ b/libavcodec/nvenc.c
+@@ -2078,8 +2078,10 @@ static av_cold int nvenc_alloc_surface(AVCodecContext *avctx, int idx)
+     nv_status = p_nvenc->nvEncCreateBitstreamBuffer(ctx->nvencoder, &allocOut);
+     if (nv_status != NV_ENC_SUCCESS) {
+         int err = nvenc_print_error(avctx, nv_status, "CreateBitstreamBuffer failed");
+-        if (avctx->pix_fmt != AV_PIX_FMT_CUDA && avctx->pix_fmt != AV_PIX_FMT_D3D11)
++        if (avctx->pix_fmt != AV_PIX_FMT_CUDA && avctx->pix_fmt != AV_PIX_FMT_D3D11) {
+             p_nvenc->nvEncDestroyInputBuffer(ctx->nvencoder, ctx->surfaces[idx].input_surface);
++            ctx->surfaces[idx].input_surface = NULL;
++        }
+         av_frame_free(&ctx->surfaces[idx].in_ref);
+         return err;
+     }
+@@ -2213,10 +2215,12 @@ av_cold int ff_nvenc_encode_close(AVCodecContext *avctx)
+ 
+     if (ctx->surfaces) {
+         for (i = 0; i < ctx->nb_surfaces; ++i) {
+-            if (avctx->pix_fmt != AV_PIX_FMT_CUDA && avctx->pix_fmt != AV_PIX_FMT_D3D11)
++            if (avctx->pix_fmt != AV_PIX_FMT_CUDA && avctx->pix_fmt != AV_PIX_FMT_D3D11 &&
++                ctx->surfaces[i].input_surface)
+                 p_nvenc->nvEncDestroyInputBuffer(ctx->nvencoder, ctx->surfaces[i].input_surface);
+             av_frame_free(&ctx->surfaces[i].in_ref);
+-            p_nvenc->nvEncDestroyBitstreamBuffer(ctx->nvencoder, ctx->surfaces[i].output_surface);
++            if (ctx->surfaces[i].output_surface)
++                p_nvenc->nvEncDestroyBitstreamBuffer(ctx->nvencoder, ctx->surfaces[i].output_surface);
+         }
+     }
+     av_freep(&ctx->surfaces);


### PR DESCRIPTION
See https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/24019

<details><summary>Claude's draft</summary>

ffmpeg aborts with a glibc heap error (SIGABRT, rc 134) instead of exiting cleanly when nvEncCreateBitstreamBuffer() fails during encoder init.

libavcodec/nvenc.c:nvenc_alloc_surface() destroys the input buffer on that error path but leaves ctx->surfaces[idx].input_surface pointing at the destroyed handle. All three nvenc encoders set FF_CODEC_CAP_INIT_CLEANUP, so ff_nvenc_encode_close() runs after the failed init and destroys the same handle a second time. The driver frees a host-heap object there, so glibc aborts the process.

This matters for anything that probes encoder support by running ffmpeg and checking the exit status: a crashed subprocess is indistinguishable from any other failure, and production code can be driven into the abort.

Reproducer, needs only H.264 NVENC:

    ffmpeg -f lavfi -i nullsrc=s=4096x4096 -frames:v 1 \
           -vcodec h264_nvenc -surfaces 64 -f null -
    [h264_nvenc] CreateBitstreamBuffer failed: out of memory (10):
    free(): invalid pointer
    -> rc 134

4096x4096 is H.264 NVENC's largest picture and 64 is MAX_REGISTERED_FRAMES, so the request exceeds the driver's per-session bitstream-buffer budget and nvEncCreateBitstreamBuffer() legitimately fails. Verified on an RTX 5000 Ada, driver 610.43.02: unpatched 8.1.2 aborts 3/3; 8.1.2 built with this patch reports the error and exits 244 (AVERROR(ENOMEM)) 2/2, with 1920x1080 h264_nvenc and av1_nvenc encodes still succeeding.

Upstream report: https://code.ffmpeg.org/FFmpeg/FFmpeg/issues/24019

The patch applies unchanged to 8.1.2 and 9.0.

Resume this Claude session:
```
claude --resume bd61b4ef-65a2-4cb8-9ebf-2e3066a75953
```
</details>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
